### PR TITLE
Persist auth state and add logout option

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <!-- Hauptcontainer -->
   <header>
     <h1>Charakterbogen</h1>
+    <button id="logout" style="display:none">Logout</button>
   </header>
 
   <!-- Multi-Charakter Verwaltung -->

--- a/js/logic.js
+++ b/js/logic.js
@@ -7,15 +7,31 @@ function initPasswordProtection() {
   const overlay = document.getElementById("password-overlay");
   const input = document.getElementById("password-input");
   const button = document.getElementById("password-submit");
+  const logoutBtn = document.getElementById("logout");
+
+  if (localStorage.getItem("auth") === "true") {
+    overlay.style.display = "none";
+    if (logoutBtn) logoutBtn.style.display = "inline-block";
+    initLogic();
+  }
 
   button.addEventListener("click", () => {
     if (input.value === "1234") {
       overlay.style.display = "none";
+      localStorage.setItem("auth", "true");
+      if (logoutBtn) logoutBtn.style.display = "inline-block";
       initLogic();
     } else {
       alert("Falsches Passwort!");
     }
   });
+
+  if (logoutBtn) {
+    logoutBtn.addEventListener("click", () => {
+      localStorage.removeItem("auth");
+      location.reload();
+    });
+  }
 }
 document.addEventListener("DOMContentLoaded", initPasswordProtection);
 


### PR DESCRIPTION
## Summary
- persist login across sessions by storing auth in localStorage and auto-hiding overlay
- add logout button to reset auth and show password overlay again

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b82bd9088330950f095ef4016c63