### PR TITLE
Refactor armor overview layout and enforce non-scrolling tables

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,6 +5,7 @@ body {
   padding: 0;
   background: #FAF0E6;
   color: #111;
+  overflow-x: hidden;
 }
 
 h1, h2, h3 {
@@ -55,6 +56,8 @@ table {
   border-collapse: collapse;
   width: 100%;
   margin: 10px 0;
+  table-layout: fixed;
+  word-wrap: break-word;
 }
 
 th, td {
@@ -158,4 +161,14 @@ button.delete-row {
   border: none;
   cursor: pointer;
   font-size: 18px;
+}
+
+/* Rüstungsübersicht vertikal */
+.ruestung-uebersicht th,
+.ruestung-uebersicht td {
+  text-align: left;
+}
+
+.ruestung-uebersicht input {
+  width: 100%;
 }

--- a/js/sections.js
+++ b/js/sections.js
@@ -196,9 +196,13 @@ sections.push(
     content: `
       <!-- Übersicht RP pro Zone -->
       <table class="ruestung-uebersicht">
-        <tr><th>Zone</th><th>01–09</th><th>10–24</th><th>25–44</th><th>80–89</th><th>90–100</th></tr>
-        <tr><td>Trefferzone</td><td>Kopf</td><td>Linker Arm</td><td>Rechter Arm</td><td>Linkes Bein</td><td>Rechtes Bein</td></tr>
-        <tr><td>RP gesamt</td><td><input id="rp-kopf" readonly></td><td><input id="rp-larm" readonly></td><td><input id="rp-rarm" readonly></td><td><input id="rp-lbein" readonly></td><td><input id="rp-rbein" readonly></td></tr>
+        <tr><th>Trefferzone</th><th>Trefferbereich</th><th>Summe RP</th></tr>
+        <tr><td>Kopf</td><td>01–09</td><td><input id="rp-kopf" readonly></td></tr>
+        <tr><td>Linker Arm</td><td>10–24</td><td><input id="rp-larm" readonly></td></tr>
+        <tr><td>Rechter Arm</td><td>25–44</td><td><input id="rp-rarm" readonly></td></tr>
+        <tr><td>Brust</td><td>45–79</td><td><input id="rp-brust" readonly></td></tr>
+        <tr><td>Linkes Bein</td><td>80–89</td><td><input id="rp-lbein" readonly></td></tr>
+        <tr><td>Rechtes Bein</td><td>90–100</td><td><input id="rp-rbein" readonly></td></tr>
       </table>
 
       <!-- Dynamische Rüstungsteile -->


### PR DESCRIPTION
## Summary
- Prevent horizontal scrolling by hiding body overflow and fixing table layout.
- Display armor point overview vertically with one row per hit zone including Brust.
- Style armor overview table for vertical orientation.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b0b831e1808330a39658fe58d30948