### PR TITLE
feat: highlight attribute columns

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -98,7 +98,7 @@ input[readonly], .readonly {
 }
 
 /* Highlighting */
-tr.active, td.active {
+tr.active, td.active, th.active {
   outline: 2px solid darkred;
 }
 

--- a/js/logic.js
+++ b/js/logic.js
@@ -449,19 +449,35 @@ function updateErfahrung() {
 // =========================
 document.addEventListener("focusin", e => {
   if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") {
-    const cell = e.target.closest("td");
+    const table = e.target.closest("table");
+    const cell = e.target.closest("td, th");
     const row = e.target.closest("tr");
-    if (cell) cell.classList.add("active");
-    if (row) row.classList.add("active");
+    if (table && table.id === "attribute-table" && cell) {
+      const idx = cell.cellIndex;
+      table.querySelectorAll("tr").forEach(r => {
+        const c = r.cells[idx];
+        if (c) c.classList.add("active");
+      });
+    } else if (row) {
+      row.classList.add("active");
+    }
   }
 });
 
 document.addEventListener("focusout", e => {
   if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") {
-    const cell = e.target.closest("td");
+    const table = e.target.closest("table");
+    const cell = e.target.closest("td, th");
     const row = e.target.closest("tr");
-    if (cell) cell.classList.remove("active");
-    if (row) row.classList.remove("active");
+    if (table && table.id === "attribute-table" && cell) {
+      const idx = cell.cellIndex;
+      table.querySelectorAll("tr").forEach(r => {
+        const c = r.cells[idx];
+        if (c) c.classList.remove("active");
+      });
+    } else if (row) {
+      row.classList.remove("active");
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- highlight entire column in attribute table on input focus
- keep row-level highlighting for other tables
- style updates to support highlighted table headers

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b8374fb08330a3e4906f7a87a8a3