### PR TITLE
Align table columns to the left

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -71,6 +71,30 @@ th {
   font-weight: bold;
 }
 
+td:first-child,
+th:first-child {
+  text-align: left;
+}
+
+td:first-child input,
+th:first-child input,
+td:first-child textarea,
+th:first-child textarea {
+  text-align: left;
+}
+
+td.text-left,
+th.text-left {
+  text-align: left;
+}
+
+td.text-left input,
+th.text-left input,
+td.text-left textarea,
+th.text-left textarea {
+  text-align: left;
+}
+
 /* 100% Tabellenbreite */
 .full-width {
   width: 100%;

--- a/js/logic.js
+++ b/js/logic.js
@@ -217,7 +217,7 @@ function addRow(tableId) {
   else if (tableId === "waffen-table") {
     row.innerHTML = `
       <td><input type="text"></td>
-      <td><input type="text"></td>
+      <td class="text-left"><input type="text"></td>
       <td><input type="number"></td>
       <td><input type="text"></td>
       <td><textarea></textarea></td>

--- a/js/sections.js
+++ b/js/sections.js
@@ -177,7 +177,7 @@ sections.push(
       <table class="full-width" id="waffen-table">
         <tr>
           <th>Name</th>
-          <th>Gruppe</th>
+          <th class="text-left">Gruppe</th>
           <th>TP</th>
           <th>RW</th>
           <th>Notizen</th>


### PR DESCRIPTION
## Summary
- left-align first table column and nested inputs/textarea for consistent presentation
- add `.text-left` utility class and apply to weapon "Gruppe" column to support other column orders

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b8767900833082ebfacd98c54298