### PR TITLE
Add collapsible Grunddaten section

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -472,6 +472,19 @@ function initLogic() {
   renderSections();
   initCharacterManagement();
 
+  // Toggle visibility of Grunddaten section
+  const grundHeader = document.querySelector("#grunddaten h2");
+  const grundBody = document.querySelector("#grunddaten .section-body");
+  if (grundHeader && grundBody) {
+    const collapsed = localStorage.getItem("grunddaten-collapsed") === "true";
+    grundBody.style.display = collapsed ? "none" : "";
+    grundHeader.addEventListener("click", () => {
+      const isCollapsed = grundBody.style.display === "none";
+      grundBody.style.display = isCollapsed ? "" : "none";
+      localStorage.setItem("grunddaten-collapsed", (!isCollapsed).toString());
+    });
+  }
+
   document.querySelectorAll("input, textarea, select").forEach(el => {
     el.addEventListener("input", () => {
       updateAttributes();

--- a/js/sections.js
+++ b/js/sections.js
@@ -7,33 +7,35 @@ const sections = [
     id: "grunddaten",
     title: "Grunddaten",
     content: `
-      <div class="subsection">
-        <h3>Identität</h3>
-        <table class="full-width">
-          <tr><td>Name</td><td><input type="text" id="char-name"></td></tr>
-          <tr><td>Volk</td><td><input type="text" id="char-volk"></td></tr>
-          <tr><td>Geschlecht</td><td><input type="text" id="char-geschlecht"></td></tr>
-        </table>
+      <div class="section-body">
+        <div class="subsection">
+          <h3>Identität</h3>
+          <table class="full-width">
+            <tr><td>Name</td><td><input type="text" id="char-name"></td></tr>
+            <tr><td>Volk</td><td><input type="text" id="char-volk"></td></tr>
+            <tr><td>Geschlecht</td><td><input type="text" id="char-geschlecht"></td></tr>
+          </table>
+        </div>
+        <div class="subsection">
+          <h3>Karriere</h3>
+          <table class="full-width">
+            <tr><td>Karriere</td><td><input type="text" id="char-karriere"></td></tr>
+            <tr><td>Karrierestufe</td><td><input type="text" id="char-stufe"></td></tr>
+            <tr><td>Karriereweg</td><td><input type="text" id="char-weg"></td></tr>
+            <tr><td>Status</td><td><input type="text" id="char-status"></td></tr>
+          </table>
+        </div>
+        <div class="subsection">
+          <h3>Erscheinung</h3>
+          <table class="full-width">
+            <tr><td>Alter</td><td><input type="text" id="char-alter"></td></tr>
+            <tr><td>Körpergröße</td><td><input type="text" id="char-groesse"></td></tr>
+            <tr><td>Haare</td><td><input type="text" id="char-haare"></td></tr>
+            <tr><td>Augen</td><td><input type="text" id="char-augen"></td></tr>
+          </table>
+        </div>
+        <div class="section-divider"></div>
       </div>
-      <div class="subsection">
-        <h3>Karriere</h3>
-        <table class="full-width">
-          <tr><td>Karriere</td><td><input type="text" id="char-karriere"></td></tr>
-          <tr><td>Karrierestufe</td><td><input type="text" id="char-stufe"></td></tr>
-          <tr><td>Karriereweg</td><td><input type="text" id="char-weg"></td></tr>
-          <tr><td>Status</td><td><input type="text" id="char-status"></td></tr>
-        </table>
-      </div>
-      <div class="subsection">
-        <h3>Erscheinung</h3>
-        <table class="full-width">
-          <tr><td>Alter</td><td><input type="text" id="char-alter"></td></tr>
-          <tr><td>Körpergröße</td><td><input type="text" id="char-groesse"></td></tr>
-          <tr><td>Haare</td><td><input type="text" id="char-haare"></td></tr>
-          <tr><td>Augen</td><td><input type="text" id="char-augen"></td></tr>
-        </table>
-      </div>
-      <div class="section-divider"></div>
     `
   },
 


### PR DESCRIPTION
## Summary
- Wrap Grunddaten subsections in a `.section-body`
- Toggle Grunddaten visibility via heading click and persist state with `localStorage`

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b87b386083308d8e89a7ec3e3cea