### PR TITLE
feat: add experience slider and dynamic calc

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -159,3 +159,49 @@ button.delete-row {
   cursor: pointer;
   font-size: 18px;
 }
+
+/* Slider für Erfahrungstoggle */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 50px;
+  height: 24px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #ccc;
+  transition: .4s;
+  border-radius: 24px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 20px;
+  width: 20px;
+  left: 2px;
+  bottom: 2px;
+  background: #fff;
+  transition: .4s;
+  border-radius: 50%;
+}
+
+.switch input:checked + .slider {
+  background: #2196F3;
+}
+
+.switch input:checked + .slider:before {
+  transform: translateX(26px);
+}

--- a/js/logic.js
+++ b/js/logic.js
@@ -203,7 +203,7 @@ function addRow(tableId) {
       <td><input type="number" readonly></td>
       <td><input type="number"></td>
       <td><input type="number" readonly></td>
-      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); saveState();">❌</button></td>
+      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); updateAttributes();">❌</button></td>
     `;
   }
   else if (tableId === "talent-table") {
@@ -211,7 +211,7 @@ function addRow(tableId) {
       <td>◯</td>
       <td><input type="text"></td>
       <td><input type="text"></td>
-      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); saveState();">❌</button></td>
+      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); updateAttributes();">❌</button></td>
     `;
   }
   else if (tableId === "waffen-table") {
@@ -221,7 +221,7 @@ function addRow(tableId) {
       <td><input type="number"></td>
       <td><input type="text"></td>
       <td><textarea></textarea></td>
-      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); saveState();">❌</button></td>
+      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); updateAttributes();">❌</button></td>
     `;
   }
   else if (tableId === "ruestung-table") {
@@ -237,7 +237,7 @@ function addRow(tableId) {
       <td><input type="number"></td>
       <td><input type="number"></td>
       <td><textarea></textarea></td>
-      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); saveState();">❌</button></td>
+      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); updateAttributes();">❌</button></td>
     `;
   }
   else if (tableId === "ausruestung-table") {
@@ -246,7 +246,7 @@ function addRow(tableId) {
       <td><input type="number"></td>
       <td><input type="number"></td>
       <td><textarea></textarea></td>
-      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); saveState();">❌</button></td>
+      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); updateAttributes();">❌</button></td>
     `;
   }
   else if (tableId === "zauber-table") {
@@ -257,7 +257,7 @@ function addRow(tableId) {
       <td><input type="text"></td>
       <td><input type="text"></td>
       <td><textarea></textarea></td>
-      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); saveState();">❌</button></td>
+      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); updateAttributes();">❌</button></td>
     `;
   }
   else if (tableId === "mutationen-table") {
@@ -267,23 +267,24 @@ function addRow(tableId) {
         <select><option>Körper</option><option>Geist</option></select>
       </td>
       <td><textarea></textarea></td>
-      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); saveState();">❌</button></td>
+      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); updateAttributes();">❌</button></td>
     `;
   }
   else if (tableId === "psychologie-table") {
     row.innerHTML = `
       <td><input type="text"></td>
       <td><textarea></textarea></td>
-      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); saveState();">❌</button></td>
+      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); updateAttributes();">❌</button></td>
     `;
   }
   else if (tableId === "exp-table") {
     row.innerHTML = `
       <td><input type="number"></td>
       <td><input type="text"></td>
-      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); saveState(); updateErfahrung();">❌</button></td>
+      <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); updateAttributes();">❌</button></td>
     `;
   }
+  updateAttributes();
 }
 
 // =========================
@@ -431,16 +432,16 @@ function updateErfahrung() {
     document.getElementById("exp-simple-gesamt").value = akt + ausg;
   } else {
     // Voller Modus
-    let akt = 0, ausg = 0;
+    let aktuell = 0, ausg = 0;
     document.querySelectorAll("#exp-table tr").forEach((row, idx) => {
       if (idx === 0) return;
       const val = parseInt(row.cells[0].querySelector("input").value) || 0;
-      if (val >= 0) akt += val;
-      else ausg += Math.abs(val);
+      aktuell += val;
+      if (val < 0) ausg += -val;
     });
-    document.getElementById("exp-full-akt").value = akt;
+    document.getElementById("exp-full-akt").value = aktuell;
     document.getElementById("exp-full-ausg").value = ausg;
-    document.getElementById("exp-full-gesamt").value = akt + ausg;
+    document.getElementById("exp-full-gesamt").value = aktuell + ausg;
   }
 }
 
@@ -472,11 +473,10 @@ function initLogic() {
   renderSections();
   initCharacterManagement();
 
-  document.querySelectorAll("input, textarea, select").forEach(el => {
-    el.addEventListener("input", () => {
+  document.addEventListener("input", e => {
+    if (e.target.matches("input, textarea, select")) {
       updateAttributes();
-      saveState();
-    });
+    }
   });
 
   const toggle = document.getElementById("exp-toggle");
@@ -489,8 +489,7 @@ function initLogic() {
         document.getElementById("exp-simple").style.display = "none";
         document.getElementById("exp-full").style.display = "block";
       }
-      updateErfahrung();
-      saveState();
+      updateAttributes();
     });
   }
 


### PR DESCRIPTION
## Summary
- style experience toggle as a slider
- compute experience using net and spent values
- delegate input handling to document for dynamic fields

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b92ab21083308b00bb371aba2585