### PR TITLE
Add armor overview and RP aggregation

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -156,6 +156,7 @@ function updateAttributes() {
   updateGrundfaehigkeiten();
   updateLebenspunkte();
   updateKorruption();
+  updateRuestung();
   updateTraglast();
   updateVermoegen();
   updateErfahrung();
@@ -342,6 +343,35 @@ function updateKorruption() {
   } else {
     document.getElementById("korruption-akt").classList.remove("readonly-red");
   }
+}
+
+// =========================
+// 🛡️ Rüstung
+// =========================
+function updateRuestung() {
+  const zones = {
+    "Kopf": 0,
+    "Linker Arm": 0,
+    "Rechter Arm": 0,
+    "Brust": 0,
+    "Linkes Bein": 0,
+    "Rechtes Bein": 0
+  };
+
+  document.querySelectorAll("#ruestung-table tr").forEach((row, idx) => {
+    if (idx === 0) return;
+    const zoneSel = row.cells[1].querySelector("select");
+    const zone = zoneSel ? zoneSel.value : "";
+    const rp = parseInt(row.cells[2].querySelector("input").value) || 0;
+    if (zones.hasOwnProperty(zone)) zones[zone] += rp;
+  });
+
+  document.getElementById("rp-kopf").value = zones["Kopf"] || 0;
+  document.getElementById("rp-larm").value = zones["Linker Arm"] || 0;
+  document.getElementById("rp-rarm").value = zones["Rechter Arm"] || 0;
+  document.getElementById("rp-brust").value = zones["Brust"] || 0;
+  document.getElementById("rp-lbein").value = zones["Linkes Bein"] || 0;
+  document.getElementById("rp-rbein").value = zones["Rechtes Bein"] || 0;
 }
 
 // =========================

--- a/js/sections.js
+++ b/js/sections.js
@@ -196,9 +196,13 @@ sections.push(
     content: `
       <!-- Übersicht RP pro Zone -->
       <table class="ruestung-uebersicht">
-        <tr><th>Zone</th><th>01–09</th><th>10–24</th><th>25–44</th><th>80–89</th><th>90–100</th></tr>
-        <tr><td>Trefferzone</td><td>Kopf</td><td>Linker Arm</td><td>Rechter Arm</td><td>Linkes Bein</td><td>Rechtes Bein</td></tr>
-        <tr><td>RP gesamt</td><td><input id="rp-kopf" readonly></td><td><input id="rp-larm" readonly></td><td><input id="rp-rarm" readonly></td><td><input id="rp-lbein" readonly></td><td><input id="rp-rbein" readonly></td></tr>
+        <tr><th>Trefferzone</th><th>Trefferbereich</th><th>Summe RP</th></tr>
+        <tr><td>Kopf</td><td>01–09</td><td><input id="rp-kopf" readonly></td></tr>
+        <tr><td>Linker Arm</td><td>10–24</td><td><input id="rp-larm" readonly></td></tr>
+        <tr><td>Rechter Arm</td><td>25–44</td><td><input id="rp-rarm" readonly></td></tr>
+        <tr><td>Brust</td><td>45–79</td><td><input id="rp-brust" readonly></td></tr>
+        <tr><td>Linkes Bein</td><td>80–89</td><td><input id="rp-lbein" readonly></td></tr>
+        <tr><td>Rechtes Bein</td><td>90–100</td><td><input id="rp-rbein" readonly></td></tr>
       </table>
 
       <!-- Dynamische Rüstungsteile -->


### PR DESCRIPTION
## Summary
- refactor armor section to show zone, range and RP sum rows
- compute armor RP totals per zone and hook into attribute updates

## Testing
- `node --check js/sections.js`
- `node --check js/logic.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b92f21488330baa9a0ce0b3732c4