### PR TITLE
Add attribute marker toggling with persistence

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -140,7 +140,38 @@ function loadState() {
   });
 
   updateAttributes();
+  restoreMarkers();
 }
+
+// =========================
+// 🔘 Markierungen
+// =========================
+function toggleMarker(el) {
+  const hid = document.getElementById(el.dataset.input);
+  if (!hid) return;
+  if (hid.value === "1") {
+    hid.value = "0";
+    el.textContent = "◯";
+  } else {
+    hid.value = "1";
+    el.textContent = "✚";
+  }
+  saveState();
+}
+
+function restoreMarkers() {
+  document.querySelectorAll(".marker").forEach(el => {
+    const hid = document.getElementById(el.dataset.input);
+    if (!hid) return;
+    el.textContent = hid.value === "1" ? "✚" : "◯";
+  });
+}
+
+document.addEventListener("click", e => {
+  if (e.target.classList.contains("marker")) {
+    toggleMarker(e.target);
+  }
+});
 // =========================
 // 📊 Attribute Berechnungen
 // =========================

--- a/js/sections.js
+++ b/js/sections.js
@@ -49,6 +49,19 @@ const sections = [
           <th>I</th><th>GW</th><th>GS</th><th>IN</th><th>WK</th><th>CH</th>
         </tr>
         <tr>
+          <td>Mark</td>
+          <td><span class="marker" data-input="KG-mark">◯</span><input type="hidden" id="KG-mark" value="0"></td>
+          <td><span class="marker" data-input="BF-mark">◯</span><input type="hidden" id="BF-mark" value="0"></td>
+          <td><span class="marker" data-input="ST-mark">◯</span><input type="hidden" id="ST-mark" value="0"></td>
+          <td><span class="marker" data-input="WI-mark">◯</span><input type="hidden" id="WI-mark" value="0"></td>
+          <td><span class="marker" data-input="I-mark">◯</span><input type="hidden" id="I-mark" value="0"></td>
+          <td><span class="marker" data-input="GW-mark">◯</span><input type="hidden" id="GW-mark" value="0"></td>
+          <td><span class="marker" data-input="GS-mark">◯</span><input type="hidden" id="GS-mark" value="0"></td>
+          <td><span class="marker" data-input="IN-mark">◯</span><input type="hidden" id="IN-mark" value="0"></td>
+          <td><span class="marker" data-input="WK-mark">◯</span><input type="hidden" id="WK-mark" value="0"></td>
+          <td><span class="marker" data-input="CH-mark">◯</span><input type="hidden" id="CH-mark" value="0"></td>
+        </tr>
+        <tr>
           <td>Anfang</td>
           <td><input type="number" id="KG-start"></td>
           <td><input type="number" id="BF-start"></td>


### PR DESCRIPTION
## Summary
- Add marker row to attribute table using circle and heavy cross icons
- Implement generic marker toggle handler with state save/restore

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b982069c83308c6583d28b525785