### PR TITLE
Make Grunddaten collapsible and unify column widths

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -91,6 +91,11 @@ th.text-left {
   text-align: left;
 }
 
+th.wsg,
+td.wsg {
+  width: 60px;
+}
+
 td.text-left input,
 th.text-left input,
 td.text-left textarea,

--- a/js/logic.js
+++ b/js/logic.js
@@ -123,6 +123,25 @@ function renderSections() {
   });
 }
 
+function initGrunddatenToggle() {
+  const section = document.getElementById("grunddaten");
+  if (!section) return;
+  const body = section.querySelector(".section-body");
+  const header = section.querySelector("h2");
+  if (!body || !header) return;
+  const collapsed = localStorage.getItem("grunddaten-collapsed") === "true";
+  if (collapsed) body.style.display = "none";
+  header.addEventListener("click", () => {
+    if (body.style.display === "none") {
+      body.style.display = "block";
+      localStorage.setItem("grunddaten-collapsed", "false");
+    } else {
+      body.style.display = "none";
+      localStorage.setItem("grunddaten-collapsed", "true");
+    }
+  });
+}
+
 // =========================
 // 💾 Speicher- und Lade-Logik
 // =========================
@@ -322,9 +341,9 @@ function addRow(tableId) {
           <option value="WK">WK</option><option value="CH">CH</option>
         </select>
       </td>
-      <td><input type="number" readonly></td>
-      <td><input type="number"></td>
-      <td><input type="number" readonly></td>
+      <td class="wsg"><input type="number" readonly></td>
+      <td class="wsg"><input type="number"></td>
+      <td class="wsg"><input type="number" readonly></td>
       <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); saveState(); updateLebenspunkte();">❌</button></td>
     `;
   }
@@ -643,6 +662,7 @@ document.addEventListener("focusout", e => {
 // =========================
 function initLogic() {
   renderSections();
+  initGrunddatenToggle();
   initCharacterManagement();
 
   document.addEventListener("input", e => {

--- a/js/sections.js
+++ b/js/sections.js
@@ -7,33 +7,35 @@ const sections = [
     id: "grunddaten",
     title: "Grunddaten",
     content: `
-      <div class="subsection">
-        <h3>Identität</h3>
-        <table class="full-width">
-          <tr><td>Name</td><td><input type="text" id="char-name"></td></tr>
-          <tr><td>Volk</td><td><input type="text" id="char-volk"></td></tr>
-          <tr><td>Geschlecht</td><td><input type="text" id="char-geschlecht"></td></tr>
-        </table>
+      <div class="section-body">
+        <div class="subsection">
+          <h3>Identität</h3>
+          <table class="full-width">
+            <tr><td>Name</td><td><input type="text" id="char-name"></td></tr>
+            <tr><td>Volk</td><td><input type="text" id="char-volk"></td></tr>
+            <tr><td>Geschlecht</td><td><input type="text" id="char-geschlecht"></td></tr>
+          </table>
+        </div>
+        <div class="subsection">
+          <h3>Karriere</h3>
+          <table class="full-width">
+            <tr><td>Karriere</td><td><input type="text" id="char-karriere"></td></tr>
+            <tr><td>Karrierestufe</td><td><input type="text" id="char-stufe"></td></tr>
+            <tr><td>Karriereweg</td><td><input type="text" id="char-weg"></td></tr>
+            <tr><td>Status</td><td><input type="text" id="char-status"></td></tr>
+          </table>
+        </div>
+        <div class="subsection">
+          <h3>Erscheinung</h3>
+          <table class="full-width">
+            <tr><td>Alter</td><td><input type="text" id="char-alter"></td></tr>
+            <tr><td>Körpergröße</td><td><input type="text" id="char-groesse"></td></tr>
+            <tr><td>Haare</td><td><input type="text" id="char-haare"></td></tr>
+            <tr><td>Augen</td><td><input type="text" id="char-augen"></td></tr>
+          </table>
+        </div>
+        <div class="section-divider"></div>
       </div>
-      <div class="subsection">
-        <h3>Karriere</h3>
-        <table class="full-width">
-          <tr><td>Karriere</td><td><input type="text" id="char-karriere"></td></tr>
-          <tr><td>Karrierestufe</td><td><input type="text" id="char-stufe"></td></tr>
-          <tr><td>Karriereweg</td><td><input type="text" id="char-weg"></td></tr>
-          <tr><td>Status</td><td><input type="text" id="char-status"></td></tr>
-        </table>
-      </div>
-      <div class="subsection">
-        <h3>Erscheinung</h3>
-        <table class="full-width">
-          <tr><td>Alter</td><td><input type="text" id="char-alter"></td></tr>
-          <tr><td>Körpergröße</td><td><input type="text" id="char-groesse"></td></tr>
-          <tr><td>Haare</td><td><input type="text" id="char-haare"></td></tr>
-          <tr><td>Augen</td><td><input type="text" id="char-augen"></td></tr>
-        </table>
-      </div>
-      <div class="section-divider"></div>
     `
   },
 
@@ -114,9 +116,9 @@ const sections = [
         <tr>
           <th>Fähigkeit</th>
           <th>At.</th>
-          <th>Wert</th>
-          <th>Steig.</th>
-          <th>Gesamt</th>
+          <th class="wsg">Wert</th>
+          <th class="wsg">Steig.</th>
+          <th class="wsg">Gesamt</th>
         </tr>
         <!-- Reihenfolge fix nach Referenz -->
         ${[
@@ -131,9 +133,9 @@ const sections = [
           <tr>
             <td>${name}</td>
             <td>${att}</td>
-            <td><input type="number" id="grund-${name}-wert" readonly></td>
-            <td><input type="number" id="grund-${name}-steig"></td>
-            <td><input type="number" id="grund-${name}-gesamt" readonly></td>
+            <td class="wsg"><input type="number" id="grund-${name}-wert" readonly></td>
+            <td class="wsg"><input type="number" id="grund-${name}-steig"></td>
+            <td class="wsg"><input type="number" id="grund-${name}-gesamt" readonly></td>
           </tr>`).join("")}
       </table>
       <div class="section-divider"></div>
@@ -150,9 +152,9 @@ const sections = [
           <th>Mark</th>
           <th>Fähigkeit</th>
           <th>At.</th>
-          <th>Wert</th>
-          <th>Steig.</th>
-          <th>Gesamt</th>
+          <th class="wsg">Wert</th>
+          <th class="wsg">Steig.</th>
+          <th class="wsg">Gesamt</th>
           <th>❌</th>
         </tr>
       </table>


### PR DESCRIPTION
## Summary
- Make "Grunddaten" section collapsible and store its open/closed state in localStorage
- Add `.wsg` CSS class and apply it to "Wert/Steig./Gesamt" columns for consistent widths

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b6ff89808330bb0bf8c010b7f640