### PR TITLE
feat: add attribute marker system

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -198,6 +198,14 @@ button.delete-row {
   text-align: left; /* Tabelle „Rüstung“ vertikal ausgerichtet */
 }
 
+/* Marker Styles */
+.attr-cross { background: #add8e6; font-weight: bold; }
+.attr-axes { background: #cd7f32; font-weight: bold; }
+.attr-skull { background: silver; font-weight: bold; }
+.attr-shield { background: gold; font-weight: bold; }
+
+.line-marked { background: #ddd; font-weight: bold; }
+
 .ruestung-uebersicht input {
   width: 100%;
 }

--- a/js/logic.js
+++ b/js/logic.js
@@ -258,30 +258,117 @@ function loadState() {
 // =========================
 // 🔘 Markierungen
 // =========================
-function toggleMarker(el) {
-  const hid = document.getElementById(el.dataset.input); // verborgenes Feld
+const attrSymbols = ["◯","✠","⚔","☠","🛡"];
+
+function updateAttrHeader(el, val) {
+  const header = document.querySelector("#attribute-table .attr-header");
+  if (!header) return;
+  const idx = el.parentElement.cellIndex;
+  const th = header.cells[idx];
+  if (!th) return;
+  th.classList.remove("attr-cross","attr-axes","attr-skull","attr-shield");
+  if (val === 1) th.classList.add("attr-cross");
+  else if (val === 2) th.classList.add("attr-axes");
+  else if (val === 3) th.classList.add("attr-skull");
+  else if (val === 4) th.classList.add("attr-shield");
+}
+
+function resetAttrMarker(el) {
+  const hid = document.getElementById(el.dataset.input);
+  if (!hid) return;
+  hid.value = "0";
+  el.textContent = attrSymbols[0];
+  updateAttrHeader(el, 0);
+}
+
+function enforceAttributeExclusivity() {
+  const groups = {1:[],2:[],3:[],4:[]};
+  document.querySelectorAll(".attr-marker").forEach(el => {
+    const hid = document.getElementById(el.dataset.input);
+    const val = parseInt(hid.value) || 0;
+    if (val > 0) groups[val].push(el);
+  });
+  let changed = false;
+  [2,3,4].forEach(v => {
+    const arr = groups[v];
+    arr.slice(1).forEach(extra => { resetAttrMarker(extra); changed = true; });
+  });
+  const crosses = groups[1];
+  if (crosses.length > 3) {
+    crosses.slice(3).forEach(extra => { resetAttrMarker(extra); changed = true; });
+  }
+  if (changed) saveState();
+}
+
+function selectAttrMarker(el) {
+  const hid = document.getElementById(el.dataset.input);
+  if (!hid) return;
+  const choice = prompt("Symbol wählen:\n0: ◯\n1: ✠\n2: ⚔\n3: ☠\n4: 🛡", hid.value);
+  if (choice === null) return;
+  const val = parseInt(choice);
+  if (isNaN(val) || val < 0 || val >= attrSymbols.length) return;
+
+  if (val === 1) {
+    const count = Array.from(document.querySelectorAll('.attr-marker')).filter(m => document.getElementById(m.dataset.input).value === "1").length;
+    if (count >= 3 && hid.value !== "1") {
+      alert("Max 3 ✠ erlaubt.");
+      return;
+    }
+  } else if (val >= 2) {
+    document.querySelectorAll('.attr-marker').forEach(m => {
+      if (m === el) return;
+      const mh = document.getElementById(m.dataset.input);
+      if (mh.value === String(val)) resetAttrMarker(m);
+    });
+  }
+
+  hid.value = String(val);
+  el.textContent = attrSymbols[val];
+  updateAttrHeader(el, val);
+  saveState();
+}
+
+function toggleLineMarker(el) {
+  const hid = el.nextElementSibling;
   if (!hid) return;
   if (hid.value === "1") {
     hid.value = "0";
-    el.textContent = "◯"; // Marker entfernen
+    el.textContent = attrSymbols[0];
+    el.closest('tr').classList.remove('line-marked');
   } else {
     hid.value = "1";
-    el.textContent = "✚"; // Marker setzen
+    el.textContent = attrSymbols[1];
+    el.closest('tr').classList.add('line-marked');
   }
   saveState();
 }
 
 function restoreMarkers() {
-  document.querySelectorAll(".marker").forEach(el => {
+  document.querySelectorAll('.attr-marker').forEach(el => {
     const hid = document.getElementById(el.dataset.input);
     if (!hid) return;
-    el.textContent = hid.value === "1" ? "✚" : "◯"; // Status wiederherstellen
+    const val = parseInt(hid.value) || 0;
+    el.textContent = attrSymbols[val];
+    updateAttrHeader(el, val);
+  });
+  enforceAttributeExclusivity();
+  document.querySelectorAll('.line-marker').forEach(el => {
+    const hid = el.nextElementSibling;
+    if (hid.value === "1") {
+      el.textContent = attrSymbols[1];
+      el.closest('tr').classList.add('line-marked');
+    } else {
+      el.textContent = attrSymbols[0];
+      el.closest('tr').classList.remove('line-marked');
+    }
   });
 }
 
 document.addEventListener("click", e => {
-  if (e.target.classList.contains("marker")) {
-    toggleMarker(e.target);
+  if (e.target.classList.contains("attr-marker")) {
+    selectAttrMarker(e.target);
+  } else if (e.target.classList.contains("line-marker")) {
+    toggleLineMarker(e.target);
   }
 });
 // =========================
@@ -310,18 +397,18 @@ function updateAttributes() {
 // 📜 Grundfähigkeiten Logik
 // =========================
 function updateGrundfaehigkeiten() {
-  const rows = document.querySelectorAll("#grund-table tr");
-  rows.forEach((row, idx) => {
-    if (idx === 0) return; // header
-    const attCell = row.cells[1];
-    if (!attCell) return;
-    const att = attCell.textContent.trim();
-    const attVal = parseInt(document.getElementById(att+"-akt").value) || 0;
-    const steig = parseInt(row.cells[3].querySelector("input").value) || 0; // individuelle Steigerung
-    row.cells[2].querySelector("input").value = attVal; // Basiswert
-    row.cells[4].querySelector("input").value = attVal + steig; // Gesamtwert
-  });
-}
+    const rows = document.querySelectorAll("#grund-table tr");
+    rows.forEach((row, idx) => {
+      if (idx === 0) return; // header
+      const attCell = row.cells[2];
+      if (!attCell) return;
+      const att = attCell.textContent.trim();
+      const attVal = parseInt(document.getElementById(att+"-akt").value) || 0;
+      const steig = parseInt(row.cells[4].querySelector("input").value) || 0; // individuelle Steigerung
+      row.cells[3].querySelector("input").value = attVal; // Basiswert
+      row.cells[5].querySelector("input").value = attVal + steig; // Gesamtwert
+    });
+  }
 
 // =========================
 // ⚔️ Gruppierte Fähigkeiten
@@ -333,7 +420,7 @@ function addRow(tableId) {
   if (tableId === "grupp-table") {
     // Vorlage für gruppierte Fähigkeiten
     row.innerHTML = `
-      <td>◯</td>
+      <td><span class="line-marker">◯</span><input type="hidden" value="0"></td>
       <td><input type="text"></td>
       <td>
         <select>
@@ -354,7 +441,7 @@ function addRow(tableId) {
   else if (tableId === "talent-table") {
     // Zeile für Talente
     row.innerHTML = `
-      <td>◯</td>
+      <td><span class="line-marker">◯</span><input type="hidden" value="0"></td>
       <td><input type="text"></td>
       <td><input type="text"></td>
       <td><button class="delete-row" onclick="this.parentElement.parentElement.remove(); saveState(); updateLebenspunkte();">❌</button></td>

--- a/js/sections.js
+++ b/js/sections.js
@@ -46,23 +46,23 @@ const sections = [
     title: "Spielwerte",
     content: `
       <table class="full-width" id="attribute-table">
-        <tr>
+        <tr class="marker-row">
+          <td></td>
+          <td><span class="attr-marker" data-input="KG-mark">◯</span><input type="hidden" id="KG-mark" value="0"></td>
+          <td><span class="attr-marker" data-input="BF-mark">◯</span><input type="hidden" id="BF-mark" value="0"></td>
+          <td><span class="attr-marker" data-input="ST-mark">◯</span><input type="hidden" id="ST-mark" value="0"></td>
+          <td><span class="attr-marker" data-input="WI-mark">◯</span><input type="hidden" id="WI-mark" value="0"></td>
+          <td><span class="attr-marker" data-input="I-mark">◯</span><input type="hidden" id="I-mark" value="0"></td>
+          <td><span class="attr-marker" data-input="GW-mark">◯</span><input type="hidden" id="GW-mark" value="0"></td>
+          <td><span class="attr-marker" data-input="GS-mark">◯</span><input type="hidden" id="GS-mark" value="0"></td>
+          <td><span class="attr-marker" data-input="IN-mark">◯</span><input type="hidden" id="IN-mark" value="0"></td>
+          <td><span class="attr-marker" data-input="WK-mark">◯</span><input type="hidden" id="WK-mark" value="0"></td>
+          <td><span class="attr-marker" data-input="CH-mark">◯</span><input type="hidden" id="CH-mark" value="0"></td>
+        </tr>
+        <tr class="attr-header">
           <th></th>
           <th>KG</th><th>BF</th><th>ST</th><th>WI</th>
           <th>I</th><th>GW</th><th>GS</th><th>IN</th><th>WK</th><th>CH</th>
-        </tr>
-        <tr>
-          <td>Mark</td>
-          <td><span class="marker" data-input="KG-mark">◯</span><input type="hidden" id="KG-mark" value="0"></td>
-          <td><span class="marker" data-input="BF-mark">◯</span><input type="hidden" id="BF-mark" value="0"></td>
-          <td><span class="marker" data-input="ST-mark">◯</span><input type="hidden" id="ST-mark" value="0"></td>
-          <td><span class="marker" data-input="WI-mark">◯</span><input type="hidden" id="WI-mark" value="0"></td>
-          <td><span class="marker" data-input="I-mark">◯</span><input type="hidden" id="I-mark" value="0"></td>
-          <td><span class="marker" data-input="GW-mark">◯</span><input type="hidden" id="GW-mark" value="0"></td>
-          <td><span class="marker" data-input="GS-mark">◯</span><input type="hidden" id="GS-mark" value="0"></td>
-          <td><span class="marker" data-input="IN-mark">◯</span><input type="hidden" id="IN-mark" value="0"></td>
-          <td><span class="marker" data-input="WK-mark">◯</span><input type="hidden" id="WK-mark" value="0"></td>
-          <td><span class="marker" data-input="CH-mark">◯</span><input type="hidden" id="CH-mark" value="0"></td>
         </tr>
         <tr>
           <td>Anfang</td>
@@ -112,9 +112,10 @@ const sections = [
   {
     id: "grundfaehigkeiten",
     title: "Grundfähigkeiten",
-    content: `
-      <table class="full-width" id="grund-table">
+      content: `
+        <table class="full-width" id="grund-table">
         <tr>
+          <th>Mark</th>
           <th>Fähigkeit</th>
           <th>At.</th>
           <th class="wsg">Wert</th>
@@ -130,18 +131,19 @@ const sections = [
           ["Nahkampf (Standard)","KG"],["Navigation","I"],["Reiten","GW"],["Rudern","ST"],
           ["Schleichen","GW"],["Tiere bezirzen","WK"],["Überleben","IN"],["Unterhalten","CH"],
           ["Wahrnehmung","I"],["Zechen","WI"]
-        ].map(([name,att]) => `
+          ].map(([name,att]) => `
           <tr>
+            <td><span class="line-marker" data-input="grund-${name}-mark">◯</span><input type="hidden" id="grund-${name}-mark" value="0"></td>
             <td>${name}</td>
             <td>${att}</td>
             <td class="wsg"><input type="number" id="grund-${name}-wert" readonly></td>
             <td class="wsg"><input type="number" id="grund-${name}-steig"></td>
             <td class="wsg"><input type="number" id="grund-${name}-gesamt" readonly></td>
           </tr>`).join("")}
-      </table>
-      <div class="section-divider"></div>
-    `
-  },
+        </table>
+        <div class="section-divider"></div>
+      `
+    },
 
   // ⚔️ Gruppierte Fähigkeiten
   {


### PR DESCRIPTION
## Summary
- enhance attribute table with flexible marker row above headers and support for new symbols
- add marker toggles to abilities and talents with localStorage persistence
- implement exclusivity rules and styling for markers across the sheet

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check js/logic.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1507a0ad4833090f56f71decfee57