### PR TITLE
Show only inner table borders

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -61,13 +61,24 @@ table {
 }
 
 th, td {
-  border: none; /* äußere Rahmen unsichtbar */
-  border-bottom: 1px solid #000; /* nur Innenlinien */
+  border: 0; /* Zellen erhalten zunächst keinen Rahmen */
   padding: 4px;
   text-align: center;
   vertical-align: middle;
   max-width: 120px; /* verhindert zu breite Felder */
   overflow: hidden;
+}
+
+/* Vertikale innere Linien: alle Zellen nach der ersten Spalte */
+td + td,
+th + th {
+  border-left: 1px solid #000;
+}
+
+/* Horizontale innere Linien: alle Zellen nach der ersten Zeile */
+tr + tr td,
+tr + tr th {
+  border-top: 1px solid #000;
 }
 
 th {


### PR DESCRIPTION
## Summary
- ensure tables show only inner borders by styling to add borders only between adjacent cells

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b17637cc70833098ba98e25bdf2404