### PR TITLE
Ensure dynamic tables start with an initial row

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -270,6 +270,29 @@ function loadState() {
 
   updateAttributes();
   restoreMarkers();
+  ensureInitialRows();
+}
+
+// =========================
+// ➕ Dynamische Tabellen – Initiale Zeilen
+// =========================
+function ensureInitialRows() {
+  [
+    "grupp-table",
+    "talent-table",
+    "waffen-table",
+    "ruestung-table",
+    "ausruestung-table",
+    "zauber-table",
+    "mutationen-table",
+    "psychologie-table",
+    "exp-table"
+  ].forEach(id => {
+    const table = document.getElementById(id);
+    if (table && table.rows.length === 1) {
+      addRow(id);
+    }
+  });
 }
 
 // =========================


### PR DESCRIPTION
## Summary
- Add ensureInitialRows helper to populate dynamic tables with a starter row on load
- Invoke the helper after restoring state so empty tables are automatically initialized

## Testing
- `node --check js/logic.js`


------
https://chatgpt.com/codex/tasks/task_e_68b177cefa948330bc956cd4bdbca185