### PR TITLE
Add labeled percent bar after talents

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -365,3 +365,32 @@ th.mark-col, td.mark-col {
 .switch input:checked + .slider:before {
   transform: translateX(26px);
 }
+
+/* Prozentbalken */
+.percent-bar-container {
+  position: relative;
+  width: 100%;
+  height: 30px;
+  margin: 20px 0;
+}
+
+.percent-bar {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  background: #000;
+  transform: translateY(-50%);
+}
+
+.percent-label {
+  position: absolute;
+  top: -10px;
+  font-size: 10px;
+  transform: translateX(-50%);
+}
+
+.percent-label.end {
+  transform: translateX(-100%);
+}

--- a/js/sections.js
+++ b/js/sections.js
@@ -184,6 +184,37 @@ const sections = [
       <div class="section-divider"></div>
     `
   },
+  // 📊 Prozentbalken
+  {
+    id: "prozentbalken",
+    title: "",
+    content: `
+      <div class="percent-bar-container">
+        <div class="percent-bar"></div>
+        <span class="percent-label" style="left:5%;">5%</span>
+        <span class="percent-label" style="left:10%;">10%</span>
+        <span class="percent-label" style="left:15%;">15%</span>
+        <span class="percent-label" style="left:20%;">20%</span>
+        <span class="percent-label" style="left:25%;">25%</span>
+        <span class="percent-label" style="left:30%;">30%</span>
+        <span class="percent-label" style="left:35%;">35%</span>
+        <span class="percent-label" style="left:40%;">40%</span>
+        <span class="percent-label" style="left:45%;">45%</span>
+        <span class="percent-label" style="left:50%;">50%</span>
+        <span class="percent-label" style="left:55%;">55%</span>
+        <span class="percent-label" style="left:60%;">60%</span>
+        <span class="percent-label" style="left:65%;">65%</span>
+        <span class="percent-label" style="left:70%;">70%</span>
+        <span class="percent-label" style="left:75%;">75%</span>
+        <span class="percent-label" style="left:80%;">80%</span>
+        <span class="percent-label" style="left:85%;">85%</span>
+        <span class="percent-label" style="left:90%;">90%</span>
+        <span class="percent-label" style="left:95%;">95%</span>
+        <span class="percent-label end" style="left:100%;">100%</span>
+      </div>
+      <div class="section-divider"></div>
+    `
+  },
 ];
 // Fortsetzung sections.js v0.8.2
 


### PR DESCRIPTION
## Summary
- add 100%-width percent bar after Talente section with labels every 5%
- style percent bar with 3px line and positioned percent labels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b19e3645908330946097dc6b146205