### PR TITLE
Reduce padding for markers and delete icons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -173,6 +173,7 @@ button.add-row {
 button.delete-row {
   font-size: 13px;
   color: red;
+  padding: 0;
 }
 
 /* Segment-Trennung */
@@ -240,6 +241,7 @@ button.delete-row {
 th.delete-col,
 td.delete-col {
   width: 20px;
+  padding: 0;
 }
 
 /* Münz-Icons */
@@ -682,6 +684,16 @@ td.delete-col {
 th.mark-col, td.mark-col {
   width: 24px;
   text-align: center !important;
+  padding: 0;
+}
+
+.marker-row td {
+  padding: 0;
+}
+
+.attr-marker,
+.line-marker {
+  padding: 0;
 }
 
 /* Auswahlpopup für Attributmarker */


### PR DESCRIPTION
## Summary
- Remove extra padding for delete buttons and delete columns
- Minimize padding for marker columns, marker rows, and marker icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b223ab1d78833094175da17476833b