### PR TITLE
Verkleinere Zeilenmarkierer-Kreis um 10%

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -712,6 +712,10 @@ th.mark-col, td.mark-col {
   padding: 0;
 }
 
+.line-marker {
+  font-size: 90%;
+}
+
 /* Kompakte Spielwerte-Tabelle */
 #attribute-table {
   width: auto;


### PR DESCRIPTION
## Summary
- shrink circle used as line marker in grouped/basic skills and talents by ~10%

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2331f48688330950560fa78d6110c