### PR TITLE
Robustheit-Lebenspunkte berücksichtigen Talentstufe

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -771,7 +771,7 @@ function checkTalentEffects() {
   let hardyLevel = 0;
   document.querySelectorAll("#talent-table tr").forEach((row, idx) => {
     if (idx === 0) return; // Kopfzeile überspringen
-    const nameInput = row.cells[0].querySelector("input");
+    const nameInput = row.cells[0].querySelector('input[type="text"]');
     if (!nameInput) return;
     const name = nameInput.value.toLowerCase().trim();
     const simRob = similarity(name, "robustheit");


### PR DESCRIPTION
## Summary
- Addieren die Stufen des Talents `Robustheit/Hardy` und nutzen sie für die Lebenspunkt-Berechnung
- Lebenspunkte aus Robustheit = abgerundeter WI-Bonus * Talentstufe

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b402fa45f883308b8ffc4b214e8d39