### PR TITLE
Align finance columns and style sin table

### DIFF
--- a/css/style-desktop.css
+++ b/css/style-desktop.css
@@ -156,14 +156,22 @@ tr + tr th {
 }
 
 .sin-table {
-  width: auto;
+  width: fit-content;
   margin: 0 auto;
+  border: 1px solid var(--color-table-line);
+}
+
+.sin-table td {
+  width: var(--coin-col-width);
 }
 
 th { font-weight: bold; }
 
 td.text-left,
 th.text-left { text-align: left; }
+
+td.text-center,
+th.text-center { text-align: center; }
 
 th.wsg,
 td.wsg { width: 35px; }

--- a/css/style-mobile.css
+++ b/css/style-mobile.css
@@ -156,14 +156,22 @@ tr + tr th {
 }
 
 .sin-table {
-  width: auto;
+  width: fit-content;
   margin: 0 auto;
+  border: 1px solid var(--color-table-line);
+}
+
+.sin-table td {
+  width: var(--coin-col-width);
 }
 
 th { font-weight: bold; }
 
 td.text-left,
 th.text-left { text-align: left; }
+
+td.text-center,
+th.text-center { text-align: center; }
 
 th.wsg,
 td.wsg { width: 35px; }

--- a/js/logic.js
+++ b/js/logic.js
@@ -999,20 +999,20 @@ function addRow(tableId) {
   else if (tableId === "schulden-table") {
     // Dynamische Schuldenliste
     row.innerHTML = `
+      <td class="text-center"><input type="number" max="0"></td>
       <td><input type="number" max="0"></td>
       <td><input type="number" max="0"></td>
-      <td><input type="number" max="0"></td>
-      <td><textarea rows="1"></textarea></td>
+      <td class="text-left"><textarea rows="1"></textarea></td>
       <td class="delete-col"><button class="delete-row" onclick="this.parentElement.parentElement.remove(); autoAddRow('schulden-table'); saveState(); updateVermoegen();">❌</button></td>
     `;
   }
   else if (tableId === "spar-table") {
     // Dynamische Sparvermögenliste
     row.innerHTML = `
+      <td class="text-center"><input type="number" min="0"></td>
       <td><input type="number" min="0"></td>
       <td><input type="number" min="0"></td>
-      <td><input type="number" min="0"></td>
-      <td><textarea rows="1"></textarea></td>
+      <td class="text-left"><textarea rows="1"></textarea></td>
       <td class="delete-col"><button class="delete-row" onclick="this.parentElement.parentElement.remove(); autoAddRow('spar-table'); saveState(); updateVermoegen();">❌</button></td>
     `;
   }
@@ -1093,7 +1093,7 @@ function addRow(tableId) {
     // Erfahrungspunkte-Modus "Voll"
     row.innerHTML = `
       <td><input type="number"></td>
-      <td><textarea rows="1"></textarea></td>
+      <td class="text-left"><textarea rows="1"></textarea></td>
       <td class="delete-col"><button class="delete-row" onclick="this.parentElement.parentElement.remove(); autoAddRow('exp-table'); saveState(); updateLebenspunkte(); updateErfahrung(); updateGruppierteFaehigkeiten();">❌</button></td>
     `;
   }

--- a/js/sections.js
+++ b/js/sections.js
@@ -354,9 +354,9 @@ sections.push(
     content: `
       <h3>Korruptionspunkte</h3>
       <table id="korruption-table">
-        <tr><th>${t('max')}</th><th>${t('current')}</th></tr>
+        <tr><th class="text-center">${t('max')}</th><th>${t('current')}</th></tr>
         <tr>
-          <td><input type="number" id="korruption-max" readonly></td>
+          <td class="text-center"><input type="number" id="korruption-max" readonly></td>
           <td><input type="number" id="korruption-akt"></td>
         </tr>
       </table>
@@ -431,9 +431,9 @@ sections.push(
     content: `
       <h3>${t('coin_possession')}</h3>
       <table id="vermoegen-table">
-        <tr><th><span class="coin gold"></span> GK</th><th><span class="coin silver"></span> S</th><th><span class="coin copper"></span> G</th></tr>
+        <tr><th class="text-center"><span class="coin gold"></span> GK</th><th><span class="coin silver"></span> S</th><th><span class="coin copper"></span> G</th></tr>
         <tr>
-          <td><input type="number" id="verm-gk"></td>
+          <td class="text-center"><input type="number" id="verm-gk"></td>
           <td><input type="number" id="verm-s"></td>
           <td><input type="number" id="verm-g"></td>
         </tr>
@@ -442,9 +442,9 @@ sections.push(
       <div id="nettovermoegen-block" style="margin-top:10px;">
         <h3>${t('net_worth')}</h3>
         <table>
-          <tr><th><span class="coin gold"></span> GK</th><th><span class="coin silver"></span> S</th><th><span class="coin copper"></span> G</th></tr>
+          <tr><th class="text-center"><span class="coin gold"></span> GK</th><th><span class="coin silver"></span> S</th><th><span class="coin copper"></span> G</th></tr>
           <tr>
-            <td><input type="number" id="netto-gk" readonly></td>
+            <td class="text-center"><input type="number" id="netto-gk" readonly></td>
             <td><input type="number" id="netto-s" readonly></td>
             <td><input type="number" id="netto-g" readonly></td>
           </tr>
@@ -456,10 +456,10 @@ sections.push(
         <h3>${t('debts')}</h3>
         <table class="full-width" id="schulden-table">
           <tr>
-            <th><span class="coin gold"></span> GK</th>
+            <th class="text-center"><span class="coin gold"></span> GK</th>
             <th><span class="coin silver"></span> S</th>
             <th><span class="coin copper"></span> G</th>
-            <th>Notizen</th>
+            <th class="text-left">Notizen</th>
             <th class="delete-col"></th>
           </tr>
         </table>
@@ -467,10 +467,10 @@ sections.push(
         <h3>${t('savings')}</h3>
         <table class="full-width" id="spar-table">
           <tr>
-            <th><span class="coin gold"></span> GK</th>
+            <th class="text-center"><span class="coin gold"></span> GK</th>
             <th><span class="coin silver"></span> S</th>
             <th><span class="coin copper"></span> G</th>
-            <th>Notizen</th>
+            <th class="text-left">Notizen</th>
             <th class="delete-col"></th>
           </tr>
         </table>
@@ -518,7 +518,7 @@ sections.push(
         </table>
        <h3>Erfahrungsänderungen erfassen</h3>
         <table class="full-width" id="exp-table">
-          <tr><th>${t('value_col')}</th><th>${t('comment_col')}</th><th class="delete-col"></th></tr>
+          <tr><th>${t('value_col')}</th><th class="text-left">${t('comment_col')}</th><th class="delete-col"></th></tr>
         </table>
           </div>
       <div class="section-divider"></div>


### PR DESCRIPTION
## Summary
- left-align notes and experience comment columns with appropriate classes
- center GK and corruption max columns across finance tables
- add border and equal column width to sin table with new `text-center` utility

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68baaf0acb34833099fa391d9b2c4ecc