### PR TITLE
fix: show column highlight border only around outer edges

### DIFF
--- a/css/style-desktop.css
+++ b/css/style-desktop.css
@@ -404,7 +404,21 @@ td.wsg { width: 35px; }
 }
 
 th.active,
-td.active,
+td.active {
+  border-left: 2px solid var(--color-active-cell);
+  border-right: 2px solid var(--color-active-cell);
+}
+
+tr:first-child th.active,
+tr:first-child td.active {
+  border-top: 2px solid var(--color-active-cell);
+}
+
+tr:last-child th.active,
+tr:last-child td.active {
+  border-bottom: 2px solid var(--color-active-cell);
+}
+
 tr.active {
   outline: 2px solid var(--color-active-cell);
 }

--- a/css/style-mobile.css
+++ b/css/style-mobile.css
@@ -405,7 +405,21 @@ td.wsg { width: 35px; }
 }
 
 th.active,
-td.active,
+td.active {
+  border-left: 2px solid var(--color-active-cell);
+  border-right: 2px solid var(--color-active-cell);
+}
+
+tr:first-child th.active,
+tr:first-child td.active {
+  border-top: 2px solid var(--color-active-cell);
+}
+
+tr:last-child th.active,
+tr:last-child td.active {
+  border-bottom: 2px solid var(--color-active-cell);
+}
+
 tr.active {
   outline: 2px solid var(--color-active-cell);
 }


### PR DESCRIPTION
## Summary
- adjust active cell highlighting so only the column's outer border is emphasized

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bae74a497c8330ab85791b9b00c561