### PR TITLE
Align input fields and tidy tables

### DIFF
--- a/css/style-desktop.css
+++ b/css/style-desktop.css
@@ -636,6 +636,9 @@ th[data-input]::before {
 #ruestung-table th:nth-child(6),
 #ruestung-table td:nth-child(6) { width: 16px; padding: 0; }
 
+.ruestung-uebersicht,
+.ruestung-uebersicht + .table-gap { display: none; }
+
 #ausruestung-table th:nth-child(1),
 #ausruestung-table td:nth-child(1) { max-width: none; width: auto; }
 #ausruestung-table th:nth-child(2),
@@ -683,6 +686,16 @@ th[data-input]::before {
 #psychologie-table td:nth-child(2) { max-width: none; width: auto; text-align: left; }
 #psychologie-table th:nth-child(3),
 #psychologie-table td:nth-child(3) { width: 16px; padding: 0; }
+
+/* Linksbündige Textareas */
+#talent-table td:nth-child(3) textarea,
+#waffen-table td:nth-child(5) textarea,
+#ruestung-table td:nth-child(5) textarea,
+#ausruestung-table td:nth-child(4) textarea,
+#zauber-table td:nth-child(6) textarea,
+#mutationen-table td:nth-child(3) textarea,
+#psychologie-table td:nth-child(2) textarea,
+#exp-table td:nth-child(2) textarea { text-align: left; }
 
 /* ================================================
    Schulden- und Spar-Tabellen
@@ -851,6 +864,10 @@ th[data-input]::before {
 .tiny-field {
   width: 2ch;
 }
+
+/* Bewegungstabelle ohne Umbruch */
+.movement-table { width: auto; table-layout: auto; }
+.movement-table td { white-space: nowrap; }
 
 .slash {
   padding: 0 4px;

--- a/css/style-mobile.css
+++ b/css/style-mobile.css
@@ -637,6 +637,9 @@ th[data-input]::before {
 #ruestung-table th:nth-child(6),
 #ruestung-table td:nth-child(6) { width: 16px; padding: 0; }
 
+.ruestung-uebersicht,
+.ruestung-uebersicht + .table-gap { display: none; }
+
 #ausruestung-table th:nth-child(1),
 #ausruestung-table td:nth-child(1) { max-width: none; width: auto; }
 #ausruestung-table th:nth-child(2),
@@ -684,6 +687,16 @@ th[data-input]::before {
 #psychologie-table td:nth-child(2) { max-width: none; width: auto; text-align: left; }
 #psychologie-table th:nth-child(3),
 #psychologie-table td:nth-child(3) { width: 16px; padding: 0; }
+
+/* Linksbündige Textareas */
+#talent-table td:nth-child(3) textarea,
+#waffen-table td:nth-child(5) textarea,
+#ruestung-table td:nth-child(5) textarea,
+#ausruestung-table td:nth-child(4) textarea,
+#zauber-table td:nth-child(6) textarea,
+#mutationen-table td:nth-child(3) textarea,
+#psychologie-table td:nth-child(2) textarea,
+#exp-table td:nth-child(2) textarea { text-align: left; }
 
 /* ================================================
    Schulden- und Spar-Tabellen
@@ -852,6 +865,10 @@ th[data-input]::before {
 .tiny-field {
   width: 2ch;
 }
+
+/* Bewegungstabelle ohne Umbruch */
+.movement-table { width: auto; table-layout: auto; }
+.movement-table td { white-space: nowrap; }
 
 .slash {
   padding: 0 4px;

--- a/js/logic.js
+++ b/js/logic.js
@@ -999,7 +999,7 @@ function addRow(tableId) {
   else if (tableId === "schulden-table") {
     // Dynamische Schuldenliste
     row.innerHTML = `
-      <td class="text-center"><input type="number" max="0"></td>
+      <td><input type="number" max="0"></td>
       <td><input type="number" max="0"></td>
       <td><input type="number" max="0"></td>
       <td class="text-left"><textarea rows="1"></textarea></td>
@@ -1009,7 +1009,7 @@ function addRow(tableId) {
   else if (tableId === "spar-table") {
     // Dynamische Sparvermögenliste
     row.innerHTML = `
-      <td class="text-center"><input type="number" min="0"></td>
+      <td><input type="number" min="0"></td>
       <td><input type="number" min="0"></td>
       <td><input type="number" min="0"></td>
       <td class="text-left"><textarea rows="1"></textarea></td>

--- a/js/sections.js
+++ b/js/sections.js
@@ -37,11 +37,11 @@ const sections = [
         </div>
         <div class="subsection">
           <h3>${t('movement')}</h3>
-          <table class="full-width movement-table">
+          <table class="movement-table">
             <tr>
-              <td>${t('movement')}</td><td><input type="number" id="char-bewegung" class="small-field" max="99"></td>
-              <td>${t('walk')}</td><td><input type="number" id="char-gehen" class="small-field" max="99"></td>
-              <td>${t('run')}</td><td><input type="number" id="char-rennen" class="small-field" max="99"></td>
+              <td>${t('movement')}</td><td><input type="number" id="char-bewegung" class="tiny-field" max="99" step="1"></td>
+              <td>${t('walk')}</td><td><input type="number" id="char-gehen" class="tiny-field" max="99" step="1"></td>
+              <td>${t('run')}</td><td><input type="number" id="char-rennen" class="tiny-field" max="99" step="1"></td>
             </tr>
           </table>
         </div>
@@ -431,9 +431,9 @@ sections.push(
     content: `
       <h3>${t('coin_possession')}</h3>
       <table id="vermoegen-table">
-        <tr><th class="text-center"><span class="coin gold"></span> GK</th><th><span class="coin silver"></span> S</th><th><span class="coin copper"></span> G</th></tr>
+        <tr><th><span class="coin gold"></span> GK</th><th><span class="coin silver"></span> S</th><th><span class="coin copper"></span> G</th></tr>
         <tr>
-          <td class="text-center"><input type="number" id="verm-gk"></td>
+          <td><input type="number" id="verm-gk"></td>
           <td><input type="number" id="verm-s"></td>
           <td><input type="number" id="verm-g"></td>
         </tr>
@@ -442,9 +442,9 @@ sections.push(
       <div id="nettovermoegen-block" style="margin-top:10px;">
         <h3>${t('net_worth')}</h3>
         <table>
-          <tr><th class="text-center"><span class="coin gold"></span> GK</th><th><span class="coin silver"></span> S</th><th><span class="coin copper"></span> G</th></tr>
+          <tr><th><span class="coin gold"></span> GK</th><th><span class="coin silver"></span> S</th><th><span class="coin copper"></span> G</th></tr>
           <tr>
-            <td class="text-center"><input type="number" id="netto-gk" readonly></td>
+            <td><input type="number" id="netto-gk" readonly></td>
             <td><input type="number" id="netto-s" readonly></td>
             <td><input type="number" id="netto-g" readonly></td>
           </tr>
@@ -456,7 +456,7 @@ sections.push(
         <h3>${t('debts')}</h3>
         <table class="full-width" id="schulden-table">
           <tr>
-            <th class="text-center"><span class="coin gold"></span> GK</th>
+            <th><span class="coin gold"></span> GK</th>
             <th><span class="coin silver"></span> S</th>
             <th><span class="coin copper"></span> G</th>
             <th class="text-left">Notizen</th>
@@ -467,7 +467,7 @@ sections.push(
         <h3>${t('savings')}</h3>
         <table class="full-width" id="spar-table">
           <tr>
-            <th class="text-center"><span class="coin gold"></span> GK</th>
+            <th><span class="coin gold"></span> GK</th>
             <th><span class="coin silver"></span> S</th>
             <th><span class="coin copper"></span> G</th>
             <th class="text-left">Notizen</th>


### PR DESCRIPTION
## Summary
- Left-align notes and quality textareas across dynamic tables
- Unify GK columns in financial tables and hide armor overview
- Compact movement table with two-digit fields

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68babd5a0c588330b84f0481f86e87c6