### PR TITLE
feat: prompt user about service worker updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,30 @@
       const splash = document.getElementById('splash-screen');
       if (splash) splash.style.display = 'none';
       if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register('/service-worker.js');
+        navigator.serviceWorker.register('/service-worker.js').then(reg => {
+          const promptUser = worker => {
+            if (confirm(t('update_available'))) {
+              worker.postMessage({ type: 'SKIP_WAITING' });
+            }
+          };
+
+          if (reg.waiting) {
+            promptUser(reg.waiting);
+          }
+
+          reg.addEventListener('updatefound', () => {
+            const newWorker = reg.installing;
+            newWorker.addEventListener('statechange', () => {
+              if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                promptUser(newWorker);
+              }
+            });
+          });
+
+          navigator.serviceWorker.addEventListener('controllerchange', () => {
+            window.location.reload();
+          });
+        });
       }
     });
   </script>

--- a/js/translations.js
+++ b/js/translations.js
@@ -24,6 +24,7 @@ const baseTranslations = {
   delete_confirm_suffix: " wirklich löschen?",
   settings_placeholder: "Einstellungen folgen später.",
   settings: "Einstellungen",
+  update_available: "Neue Version verfügbar – jetzt aktualisieren?",
   yes: "Ja",
   no: "Nein",
   active_character: "Aktiver Charakter:",

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,24 +1,47 @@
+const CACHE_NAME = "charakterbogen-cache-v2";
+const ASSETS = [
+  "/",              // Root
+  "/index.html",         // Hauptdokument
+  "/css/style-mobile.css",  // Styles Mobile
+  "/css/style-desktop.css", // Styles Desktop
+  "/js/sections.js",     // Struktur
+  "/js/translations.js", // Übersetzungen
+  "/js/logic.js",        // Logik
+  "/manifest.json",      // PWA Manifest
+  "/img/appicon.png",    // App-Icon
+  "/img/splash.png"      // Splashscreen
+];
+
 self.addEventListener("install", e => {
-  // Beim Installieren alle notwendigen Dateien cachen
+  self.skipWaiting();
   e.waitUntil(
-    caches.open("charakterbogen-cache").then(cache => {
-      return cache.addAll([
-        "/",              // Root
-        "/index.html",         // Hauptdokument
-        "/css/style-mobile.css",  // Styles Mobile
-        "/css/style-desktop.css", // Styles Desktop
-        "/js/sections.js",     // Struktur
-        "/js/translations.js", // Übersetzungen
-        "/js/logic.js",        // Logik
-        "/manifest.json",      // PWA Manifest
-        "/img/appicon.png",    // App-Icon
-        "/img/splash.png"      // Splashscreen
-      ]);
-    })
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
   );
 });
 
+self.addEventListener("activate", e => {
+  e.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+    )
+  );
+  self.clientsClaim();
+});
+
 self.addEventListener("fetch", e => {
-  // Versuche zuerst aus dem Cache zu antworten, ansonsten aus dem Netz
-  e.respondWith(caches.match(e.request).then(r => r || fetch(e.request)));
+  e.respondWith(
+    fetch(e.request)
+      .then(res => {
+        const resClone = res.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(e.request, resClone));
+        return res;
+      })
+      .catch(() => caches.match(e.request))
+  );
+});
+
+self.addEventListener("message", e => {
+  if (e.data && e.data.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
 });


### PR DESCRIPTION
## Summary
- version service worker cache and update strategy
- prompt users to reload when new service worker is available
- add translation for update prompt

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc1f29008833095a8226ff367e6a8