### PR TITLE
Prompt character creation on first load

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -92,6 +92,41 @@ function deleteCharacter(name) {
   loadCharacterList();
 }
 
+// Öffnet Eingabe zur Erstellung eines neuen Charakters
+function promptNewCharacter(mandatory = false) {
+  const overlay = document.createElement("div");
+  overlay.className = "overlay";
+  overlay.innerHTML = `
+    <div class="overlay-content">
+      <p>${mandatory ? t('no_character_prompt') : t('character_name_prompt')}</p>
+      <input type="text" id="new-char-name">
+      <br>
+      <button id="new-char-ok">${t('ok')}</button>
+      ${mandatory ? '' : `<button id="new-char-cancel">${t('cancel')}</button>`}
+    </div>
+  `;
+  document.body.appendChild(overlay);
+  const input = overlay.querySelector("#new-char-name");
+  input.focus();
+
+  function close() { overlay.remove(); }
+
+  if (!mandatory) {
+    overlay.addEventListener("click", e => { if (e.target === overlay) close(); });
+    overlay.querySelector("#new-char-cancel").addEventListener("click", close);
+  }
+
+  overlay.querySelector("#new-char-ok").addEventListener("click", () => {
+    const newName = input.value.trim();
+    if (!newName) { alert(t('name_required')); return; }
+    saveState();
+    saveCharacter(newName);
+    resetCharacterSheet();
+    loadCharacterList();
+    close();
+  });
+}
+
 function initCharacterManagement() {
   const cycleBtn = document.getElementById("cycle-character");
   const newBtn = document.getElementById("new-character"); // neuer Charakter
@@ -102,6 +137,9 @@ function initCharacterManagement() {
   const settingsBtn = document.getElementById("settings");
 
   loadCharacterList();
+  if (characterList.length === 0) {
+    promptNewCharacter(true);
+  }
   if (!currentCharacter) {
     ensureInitialRows();
     updateAttributes();
@@ -143,35 +181,7 @@ function initCharacterManagement() {
 
   // Neuer Charakter anlegen
   newBtn.addEventListener("click", () => {
-    const overlay = document.createElement("div");
-    overlay.className = "overlay";
-    overlay.innerHTML = `
-      <div class="overlay-content">
-        <p>${t('character_name_prompt')}</p>
-        <input type="text" id="new-char-name">
-        <br>
-        <button id="new-char-ok">${t('ok')}</button>
-        <button id="new-char-cancel">${t('cancel')}</button>
-      </div>
-    `;
-    document.body.appendChild(overlay);
-    const input = overlay.querySelector("#new-char-name");
-    input.focus();
-
-    function close() { overlay.remove(); }
-
-    overlay.addEventListener("click", e => { if (e.target === overlay) close(); });
-    overlay.querySelector("#new-char-cancel").addEventListener("click", close);
-
-    overlay.querySelector("#new-char-ok").addEventListener("click", () => {
-      const newName = input.value.trim();
-      if (!newName) { alert(t('name_required')); return; }
-      saveState();
-      saveCharacter(newName);
-      resetCharacterSheet();
-      loadCharacterList();
-      close();
-    });
+    promptNewCharacter();
   });
 
   // Charakter löschen

--- a/js/translations.js
+++ b/js/translations.js
@@ -17,6 +17,7 @@ const baseTranslations = {
   wrong_password: "Falsches Passwort!",
   import_failed: "Import fehlgeschlagen",
   character_name_prompt: "Charaktername:",
+  no_character_prompt: "Kein Charakter vorhanden. Bitte neuen Charakter anlegen:",
   cancel: "Abbrechen",
   name_required: "Name erforderlich",
   delete_confirm: "Charakter wirklich löschen?",


### PR DESCRIPTION
## Summary
- enforce character creation when no characters exist by prompting on startup
- centralize character creation overlay in `promptNewCharacter`
- add translation key for missing character prompt

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68c06cd3db9483308f71277e3cc10be4