### PR TITLE
Add character kill option with read-only freeze

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -223,18 +223,54 @@ function initCharacterManagement() {
     overlay.addEventListener("click", e => { if (e.target === overlay) close(); });
     overlay.querySelector("#del-no").addEventListener("click", close);
     overlay.querySelector("#del-kill").addEventListener("click", () => {
-      killCharacter();
-      close();
+      const confirmOverlay = document.createElement("div");
+      confirmOverlay.className = "overlay";
+      confirmOverlay.innerHTML = `
+        <div class="overlay-content">
+          <p>${t('kill_confirm')}</p>
+          <button id="kill-yes">${t('yes')}</button>
+          <button id="kill-no">${t('no')}</button>
+        </div>
+      `;
+      document.body.appendChild(confirmOverlay);
+
+      function closeConfirm() { confirmOverlay.remove(); }
+
+      confirmOverlay.addEventListener("click", e => { if (e.target === confirmOverlay) closeConfirm(); });
+      confirmOverlay.querySelector("#kill-no").addEventListener("click", closeConfirm);
+      confirmOverlay.querySelector("#kill-yes").addEventListener("click", () => {
+        killCharacter();
+        closeConfirm();
+        close();
+      });
     });
 
     overlay.querySelector("#del-yes").addEventListener("click", () => {
-      deleteCharacter(currentCharacter);
-      if (currentCharacter) {
-        loadState(); // anderen laden
-      } else {
-        resetCharacterSheet();
-      }
-      close();
+      const confirmOverlay = document.createElement("div");
+      confirmOverlay.className = "overlay";
+      confirmOverlay.innerHTML = `
+        <div class="overlay-content">
+          <p>${t('delete_confirm')}</p>
+          <button id="confirm-del-yes">${t('yes')}</button>
+          <button id="confirm-del-no">${t('no')}</button>
+        </div>
+      `;
+      document.body.appendChild(confirmOverlay);
+
+      function closeConfirm() { confirmOverlay.remove(); }
+
+      confirmOverlay.addEventListener("click", e => { if (e.target === confirmOverlay) closeConfirm(); });
+      confirmOverlay.querySelector("#confirm-del-no").addEventListener("click", closeConfirm);
+      confirmOverlay.querySelector("#confirm-del-yes").addEventListener("click", () => {
+        deleteCharacter(currentCharacter);
+        if (currentCharacter) {
+          loadState(); // anderen laden
+        } else {
+          resetCharacterSheet();
+        }
+        closeConfirm();
+        close();
+      });
     });
   });
 

--- a/js/translations.js
+++ b/js/translations.js
@@ -21,6 +21,7 @@ const baseTranslations = {
   cancel: "Abbrechen",
   name_required: "Name erforderlich",
   delete_confirm: "Charakter wirklich löschen?",
+  kill_confirm: "Charakter wirklich töten?",
   delete_confirm_prefix: "Charakter ",
   delete_confirm_suffix: " töten oder löschen?",
   settings_placeholder: "Einstellungen folgen später.",


### PR DESCRIPTION
## Summary
- Replace character deletion confirmation with options to kill, delete, or cancel
- Add kill functionality to freeze character sheet fields in read-only style
- Localize new UI strings for kill workflow

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68c18435aecc8330962861d0f03b799d