### PR TITLE
Make all sections collapsible

### DIFF
--- a/css/style-desktop.css
+++ b/css/style-desktop.css
@@ -57,6 +57,19 @@ h1, h2, h3 {
   text-align: center;
 }
 
+section > h2 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4em;
+  cursor: pointer;
+  user-select: none;
+}
+
+.section-arrow {
+  font-size: 0.9em;
+}
+
 /* Tabellen und Zellen */
 table {
   border-collapse: collapse;

--- a/css/style-mobile.css
+++ b/css/style-mobile.css
@@ -57,6 +57,19 @@ h1, h2, h3 {
   text-align: center;
 }
 
+section > h2 {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4em;
+  cursor: pointer;
+  user-select: none;
+}
+
+.section-arrow {
+  font-size: 0.9em;
+}
+
 /* Tabellen und Zellen */
 table {
   border-collapse: collapse;

--- a/js/logic.js
+++ b/js/logic.js
@@ -453,36 +453,53 @@ function renderSections() {
   sections.forEach(sec => {
     const sectionEl = document.createElement("section");
     sectionEl.id = sec.id; // ID für spätere Referenz
-    sectionEl.innerHTML = `<h2>${sec.title}</h2>${sec.content}`;
+    const header = document.createElement("h2");
+    header.innerHTML = `<span id="${sec.id}-arrow" class="section-arrow">▼</span> ${sec.title}`;
+    sectionEl.appendChild(header);
+    const body = document.createElement("div");
+    body.className = "section-body";
+    body.innerHTML = sec.content;
+    sectionEl.appendChild(body);
     main.appendChild(sectionEl); // anhängen
   });
 }
 
-function initSectionToggle(sectionId, arrowId, storageKey) {
+function initSectionToggle(sectionId) {
   const section = document.getElementById(sectionId);
   if (!section) return;
   const body = section.querySelector(".section-body");
   const header = section.querySelector("h2");
-  const arrow = header?.querySelector(`#${arrowId}`);
+  const arrow = header?.querySelector(`#${sectionId}-arrow`);
   if (!body || !header || !arrow) return;
+  const storageKey = `${sectionId}-collapsed`;
   const collapsed = localStorage.getItem(storageKey) === "true";
   if (collapsed) {
     body.style.display = "none";
     arrow.textContent = "▶";
+    section.classList.add("collapsed");
   } else {
+    body.style.display = "block";
     arrow.textContent = "▼";
+    section.classList.remove("collapsed");
   }
   header.addEventListener("click", () => {
-    if (body.style.display === "none") {
+    const isCollapsed = body.style.display === "none";
+    if (isCollapsed) {
       body.style.display = "block";
       arrow.textContent = "▼";
+      section.classList.remove("collapsed");
       localStorage.setItem(storageKey, "false");
     } else {
       body.style.display = "none";
       arrow.textContent = "▶";
+      section.classList.add("collapsed");
       localStorage.setItem(storageKey, "true");
     }
   });
+}
+
+function initSectionToggles() {
+  sections.forEach(sec => initSectionToggle(sec.id));
 }
 
 function initFinanzenToggle() {
@@ -1502,8 +1519,7 @@ document.addEventListener("focusout", e => {
 // =========================
 function initLogic() {
   renderSections();
-  initSectionToggle('grunddaten','grunddaten-arrow','grunddaten-collapsed');
-  initSectionToggle('schicksalzaehigkeit','schicksalzaehigkeit-arrow','schicksalzaehigkeit-collapsed');
+  initSectionToggles();
   initFinanzenToggle();
   initCharacterManagement();
 

--- a/js/sections.js
+++ b/js/sections.js
@@ -6,45 +6,43 @@ const sections = [
   // 🧾 Grunddaten
   {
     id: "grunddaten",
-    title: `<span id="grunddaten-arrow">▶</span> ${t('grunddaten')}`,
+    title: t('grunddaten'),
     content: `
-      <div class="section-body">
-        <div class="subsection">
-          <h3>Identität</h3>
-          <table class="full-width two-col-table">
-            <tr><td>Name</td><td><input type="text" id="char-name"></td></tr>
-            <tr><td>Volk</td><td><input type="text" id="char-volk"></td></tr>
-            <tr><td>Geschlecht</td><td><input type="text" id="char-geschlecht"></td></tr>
-          </table>
-        </div>
-        <div class="subsection">
-          <h3>Karriere</h3>
-          <table class="full-width two-col-table">
-            <tr><td>Karriere</td><td><input type="text" id="char-karriere"></td></tr>
-            <tr><td>Karrierestufe</td><td><input type="text" id="char-stufe"></td></tr>
-            <tr><td>Karriereweg</td><td><input type="text" id="char-weg"></td></tr>
-            <tr><td>Status</td><td><input type="text" id="char-status"></td></tr>
-          </table>
-        </div>
-        <div class="subsection">
-          <h3>Erscheinung</h3>
-          <table class="full-width two-col-table">
-            <tr><td>Alter</td><td><input type="text" id="char-alter"></td></tr>
-            <tr><td>Körpergröße</td><td><input type="text" id="char-groesse"></td></tr>
-            <tr><td>Haare</td><td><input type="text" id="char-haare"></td></tr>
-            <tr><td>Augen</td><td><input type="text" id="char-augen"></td></tr>
-          </table>
-        </div>
-        <div class="subsection">
-          <h3>${t('movement')}</h3>
-          <table class="movement-table">
-            <tr>
-              <td>${t('movement')}</td><td><input type="number" id="char-bewegung" class="tiny-field" max="99" step="1"></td>
-              <td>${t('walk')}</td><td><input type="number" id="char-gehen" class="tiny-field" max="99" step="1"></td>
-              <td>${t('run')}</td><td><input type="number" id="char-rennen" class="tiny-field" max="99" step="1"></td>
-            </tr>
-          </table>
-        </div>
+      <div class="subsection">
+        <h3>Identität</h3>
+        <table class="full-width two-col-table">
+          <tr><td>Name</td><td><input type="text" id="char-name"></td></tr>
+          <tr><td>Volk</td><td><input type="text" id="char-volk"></td></tr>
+          <tr><td>Geschlecht</td><td><input type="text" id="char-geschlecht"></td></tr>
+        </table>
+      </div>
+      <div class="subsection">
+        <h3>Karriere</h3>
+        <table class="full-width two-col-table">
+          <tr><td>Karriere</td><td><input type="text" id="char-karriere"></td></tr>
+          <tr><td>Karrierestufe</td><td><input type="text" id="char-stufe"></td></tr>
+          <tr><td>Karriereweg</td><td><input type="text" id="char-weg"></td></tr>
+          <tr><td>Status</td><td><input type="text" id="char-status"></td></tr>
+        </table>
+      </div>
+      <div class="subsection">
+        <h3>Erscheinung</h3>
+        <table class="full-width two-col-table">
+          <tr><td>Alter</td><td><input type="text" id="char-alter"></td></tr>
+          <tr><td>Körpergröße</td><td><input type="text" id="char-groesse"></td></tr>
+          <tr><td>Haare</td><td><input type="text" id="char-haare"></td></tr>
+          <tr><td>Augen</td><td><input type="text" id="char-augen"></td></tr>
+        </table>
+      </div>
+      <div class="subsection">
+        <h3>${t('movement')}</h3>
+        <table class="movement-table">
+          <tr>
+            <td>${t('movement')}</td><td><input type="number" id="char-bewegung" class="tiny-field" max="99" step="1"></td>
+            <td>${t('walk')}</td><td><input type="number" id="char-gehen" class="tiny-field" max="99" step="1"></td>
+            <td>${t('run')}</td><td><input type="number" id="char-rennen" class="tiny-field" max="99" step="1"></td>
+          </tr>
+        </table>
       </div>
       <div class="section-divider"></div>
     `
@@ -116,24 +114,22 @@ const sections = [
   // ⚖️ Schicksal & Zähigkeit
   {
     id: "schicksalzaehigkeit",
-    title: `<span id="schicksalzaehigkeit-arrow">▶</span> ${t('fate_resilience')}`,
+    title: t('fate_resilience'),
     content: `
-      <div class="section-body">
-        <div class="dual-table-wrapper">
-          <div>
-            <h3>${t('fate')}</h3>
-            <table class="value-table">
-              <tr><td>${t('fate')}</td><td><input type="number" id="fate-value" class="small-field" max="99" min="0"></td></tr>
-              <tr><td>${t('luck')}</td><td><input type="number" id="luck-current" class="small-field" max="99" min="0"><span class="slash">/</span><input type="number" id="luck-max" class="small-field" max="99" min="0"></td></tr>
-            </table>
-          </div>
-          <div>
-            <h3>${t('resilience')}</h3>
-            <table class="value-table">
-              <tr><td>${t('resilience')}</td><td><input type="number" id="resilience-value" class="small-field" max="99" min="0"></td></tr>
-              <tr><td>${t('resolve')}</td><td><input type="number" id="resolve-current" class="small-field" max="99" min="0"><span class="slash">/</span><input type="number" id="resolve-max" class="small-field" max="99" min="0"></td></tr>
-            </table>
-          </div>
+      <div class="dual-table-wrapper">
+        <div>
+          <h3>${t('fate')}</h3>
+          <table class="value-table">
+            <tr><td>${t('fate')}</td><td><input type="number" id="fate-value" class="small-field" max="99" min="0"></td></tr>
+            <tr><td>${t('luck')}</td><td><input type="number" id="luck-current" class="small-field" max="99" min="0"><span class="slash">/</span><input type="number" id="luck-max" class="small-field" max="99" min="0"></td></tr>
+          </table>
+        </div>
+        <div>
+          <h3>${t('resilience')}</h3>
+          <table class="value-table">
+            <tr><td>${t('resilience')}</td><td><input type="number" id="resilience-value" class="small-field" max="99" min="0"></td></tr>
+            <tr><td>${t('resolve')}</td><td><input type="number" id="resolve-current" class="small-field" max="99" min="0"><span class="slash">/</span><input type="number" id="resolve-max" class="small-field" max="99" min="0"></td></tr>
+          </table>
         </div>
       </div>
       <div class="section-divider"></div>


### PR DESCRIPTION
## Summary
- render each sheet section with a shared collapsible header and persisted toggle state so that every segment can be folded
- streamline the section definitions by removing inline arrow markup and redundant wrappers now handled by the renderer
- add common desktop and mobile styles for the clickable headers and arrow indicators

## Testing
- npm test
- npm run lint *(fails: missing ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c972618b808330841a5f1cf532beea