### PR TITLE
Fix text alignment for content input fields

### DIFF
--- a/css/style-desktop.css
+++ b/css/style-desktop.css
@@ -117,12 +117,12 @@ th:first-child textarea {
 }
 
 input[type="text"],
+input[type="number"],
 textarea {
   width: 100%;
   margin: 0;
   border: none;
   background: var(--color-field);
-  text-align: left;
   font-family: inherit;
   font-weight: bold;
   height: var(--row-height);
@@ -130,18 +130,13 @@ textarea {
   vertical-align: middle;
 }
 
-input[type="number"],
+input[type="text"],
 textarea {
-  width: 100%;
-  margin: 0;
-  border: none;
-  background: var(--color-field);
+  text-align: left;
+}
+
+input[type="number"] {
   text-align: center;
-  font-family: inherit;
-  font-weight: bold;
-  height: var(--row-height);
-  line-height: var(--row-height);
-  vertical-align: middle;
 }
 
 textarea {

--- a/css/style-mobile.css
+++ b/css/style-mobile.css
@@ -117,12 +117,12 @@ th:first-child textarea {
 }
 
 input[type="text"],
+input[type="number"],
 textarea {
   width: 100%;
   margin: 0;
   border: none;
   background: var(--color-field);
-  text-align: left;
   font-family: inherit;
   font-weight: bold;
   height: var(--row-height);
@@ -130,18 +130,13 @@ textarea {
   vertical-align: middle;
 }
 
-input[type="number"],
+input[type="text"],
 textarea {
-  width: 100%;
-  margin: 0;
-  border: none;
-  background: var(--color-field);
+  text-align: left;
+}
+
+input[type="number"] {
   text-align: center;
-  font-family: inherit;
-  font-weight: bold;
-  height: var(--row-height);
-  line-height: var(--row-height);
-  vertical-align: middle;
 }
 
 textarea {


### PR DESCRIPTION
## Summary
- centralize the shared styling for text, number, and textarea inputs on desktop and mobile stylesheets
- explicitly align textual inputs to the left while keeping numeric values centered to avoid unintended overrides

## Testing
- npm test
- npm run lint *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f58e31d4833090985a63461b7e5e