### PR TITLE
Zentriere Münzwerte in Vermögenstabellen

### DIFF
--- a/css/style-desktop.css
+++ b/css/style-desktop.css
@@ -782,6 +782,13 @@ th[data-input]::before {
   color: var(--color-negative);
 }
 
+#schulden-table td input,
+#spar-table td input,
+#vermoegen-table td input,
+#nettovermoegen-block td input {
+  text-align: center;
+}
+
 /* Münzbesitz und Nettovermögen */
 #vermoegen-table,
 #vermoegen-table th,

--- a/css/style-mobile.css
+++ b/css/style-mobile.css
@@ -782,6 +782,13 @@ th[data-input]::before {
   color: var(--color-negative);
 }
 
+#schulden-table td input,
+#spar-table td input,
+#vermoegen-table td input,
+#nettovermoegen-block td input {
+  text-align: center;
+}
+
 /* Münzbesitz und Nettovermögen */
 #vermoegen-table,
 #vermoegen-table th,


### PR DESCRIPTION
## Summary
- zentriere die Eingabefelder für GK-, S- und G-Spalten in allen Vermögens- und Finanz-Tabellen
- stelle sicher, dass die spezielle Linksausrichtung der ersten Spalte nicht mehr auf die Münzspalten wirkt

## Testing
- npm run lint *(fails: ESLint configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68d50ea065c08330840408014de7a33d