### PR TITLE
Refine desktop layout styling

### DIFF
--- a/css/style-desktop.css
+++ b/css/style-desktop.css
@@ -54,7 +54,7 @@ body {
 
 h1, h2, h3 {
   font-family: var(--font-heading);
-  margin: 10px 0;
+  margin: 6px 0;
   text-align: center;
 }
 
@@ -926,30 +926,56 @@ th[data-input]::before {
    Desktop Overrides
    ================================================ */
 main {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: 8px;
+  row-gap: 8px;
+  align-items: start;
 }
 
 main > section {
-  flex: 1 1 50%;
   box-sizing: border-box;
-  border: 4px solid var(--color-divider);
-  margin-bottom: 8px;
+  border: 1px solid var(--color-divider);
+  border-bottom: 0;
+  padding: 12px 16px;
+  background: rgba(var(--color-text-rgb), 0.01);
+  box-shadow: 0 2px 4px rgba(var(--color-text-rgb), 0.12);
+}
+
+main > section:nth-child(even) {
+  border-left: 0;
+}
+
+main > section:nth-child(n + 3) {
+  border-top: 1px solid var(--color-divider);
+}
+
+main > section:nth-last-child(-n + 2) {
+  border-bottom: 1px solid var(--color-divider);
+}
+
+main > section:last-child {
+  border-bottom: 1px solid var(--color-divider);
 }
 
 .section-divider {
   display: none;
 }
 
-input[type="text"],
-textarea {
-  width: 30ch;
+input[type="text"] {
+  width: clamp(16ch, 28ch, 42ch);
+  max-width: 100%;
 }
 
 input[type="number"] {
-  width: 3ch;
+  width: clamp(4ch, 5ch, 7ch);
+  max-width: 100%;
+}
+
+main table input,
+main table textarea,
+main table select {
+  max-width: 100%;
 }
 /* Tabellen im Desktop nur so breit wie Inhalte */
 main table {


### PR DESCRIPTION
## Summary
- switch the desktop layout to a two-column grid with slimmer borders, shared dividers and soft shadows for sections
- adjust heading spacing and section padding to tighten the vertical rhythm without affecting table sizing
- make desktop text and number inputs dynamically sized with clamp-based widths while keeping tables auto-sized

## Testing
- npm run lint *(fails: ESLint configuration missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d516a15d40833093888849c64f906f