### PR TITLE
Add dynamic status table to life points section

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -831,6 +831,7 @@ function saveState() {
 
   // Tabellen separat serialisieren
   [
+    "lp-status-table",
     "grupp-table",
     "talent-table",
     "waffen-table",
@@ -866,6 +867,7 @@ function loadState() {
   });
 
   [
+    "lp-status-table",
     "grupp-table",
     "talent-table",
     "waffen-table",
@@ -893,6 +895,7 @@ function loadState() {
 // =========================
 function ensureInitialRows() {
   [
+    "lp-status-table",
     "grupp-table",
     "talent-table",
     "waffen-table",
@@ -925,6 +928,7 @@ function resetCharacterSheet() {
   });
 
   [
+    "lp-status-table",
     "grupp-table",
     "talent-table",
     "waffen-table",
@@ -1637,6 +1641,14 @@ function addRow(tableId) {
       <td><input type="number" min="0"></td>
       <td class="text-left"><textarea rows="1"></textarea></td>
       <td class="delete-col"><button class="delete-row" onclick="this.parentElement.parentElement.remove(); autoAddRow('spar-table'); saveState(); updateVermoegen();">❌</button></td>
+    `;
+  }
+  else if (tableId === "lp-status-table") {
+    // Lebenspunkt-Statusübersicht
+    row.innerHTML = `
+      <td><textarea rows="1"></textarea></td>
+      <td><input type="number" min="0"></td>
+      <td class="delete-col"><button class="delete-row" onclick="this.parentElement.parentElement.remove(); autoAddRow('lp-status-table'); saveState(); updateLebenspunkte();">❌</button></td>
     `;
   }
   else if (tableId === "ruestung-table") {

--- a/js/sections.js
+++ b/js/sections.js
@@ -411,6 +411,14 @@ sections.push(
         <tr><td>Gesamt-LP</td><td><input type="number" id="lp-gesamt" readonly></td></tr>
         <tr><td>${t('current_lp')}</td><td><input type="number" id="lp-aktuell" min="0" max="99"></td></tr>
       </table>
+      <h3>${t('status')}</h3>
+      <table class="full-width" id="lp-status-table">
+        <tr>
+          <th>${t('status')}</th>
+          <th>${t('count')}</th>
+          <th class="delete-col"></th>
+        </tr>
+      </table>
       <p>* Automatisch durch Talent "Robustheit" / "Hardy"</p>
       <div class="section-divider"></div>
     `

--- a/js/translations.js
+++ b/js/translations.js
@@ -176,6 +176,7 @@ const baseTranslations = {
   value_col: "Wert",
   comment_col: "Kommentar",
   sin: "Sünde",
+  count: "Anzahl",
   st_bonus: "ST-Bonus",
   wi_bonus: "WI-Bonus",
   wk_bonus: "2× WK-Bonus",


### PR DESCRIPTION
## Summary
- add a translated status table to the life points section
- persist the new status entries through the existing dynamic table helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5ad77a8c88330be2fba861ca9ed41