### PR TITLE
Adjust Grundlagen column widths

### DIFF
--- a/css/style-desktop.css
+++ b/css/style-desktop.css
@@ -175,9 +175,25 @@ tr + tr th {
 }
 
 /* spezielle Tabellen */
+.two-col-table {
+  table-layout: auto;
+}
+
 .two-col-table td,
 .two-col-table th {
-  width: 50%;
+  width: auto;
+  max-width: none;
+}
+
+.two-col-table td:first-child,
+.two-col-table th:first-child {
+  width: max-content;
+  white-space: nowrap;
+}
+
+.two-col-table td:nth-child(2),
+.two-col-table th:nth-child(2) {
+  width: 100%;
 }
 
 .movement-table td + td,

--- a/css/style-mobile.css
+++ b/css/style-mobile.css
@@ -186,6 +186,7 @@ tr + tr th {
 .two-col-table td,
 .two-col-table th {
   width: 50%;
+  max-width: none;
 }
 
 .movement-table td + td,


### PR DESCRIPTION
## Summary
- allow two-column tables on desktop to size their label column by the longest text while keeping inputs flexible
- keep mobile two-column tables at an even 50% split without max-width constraints

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e38d0277b4832d9684b6302f7dd3c6