### PR TITLE
Fix initial visibility for advanced experience (Erfahrung erweitert)

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -1477,6 +1477,16 @@ function updateErfahrung() {
   }
 }
 
+function syncErfahrungMode() {
+  const toggle = document.getElementById("exp-toggle");
+  const simple = document.getElementById("exp-simple");
+  const full = document.getElementById("exp-full");
+  if (!toggle || !simple || !full) return;
+
+  simple.style.display = toggle.checked ? "none" : "block";
+  full.style.display = toggle.checked ? "block" : "none";
+}
+
 // =========================
 // 🎨 Highlighting
 // =========================
@@ -1532,19 +1542,14 @@ function initLogic() {
   const toggle = document.getElementById("exp-toggle");
   if (toggle) {
     toggle.addEventListener("change", () => {
-      if (!toggle.checked) {
-        document.getElementById("exp-simple").style.display = "block";
-        document.getElementById("exp-full").style.display = "none";
-      } else {
-        document.getElementById("exp-simple").style.display = "none";
-        document.getElementById("exp-full").style.display = "block";
-      }
+      syncErfahrungMode();
       updateErfahrung();
       saveState();
     });
   }
 
   loadState();
+  syncErfahrungMode();
   if (!currentCharacter) {
     ensureInitialRows();
     updateAttributes();


### PR DESCRIPTION
### Motivation
- Beim ersten Laden wurde der Bereich „Erfahrung (Voll)“ nicht korrekt angezeigt, wenn der Toggle bereits auf erweitert gesetzt war, und erschien erst nach manuellem Umschalten.

### Description
- Extrahiert die Umschalt-Logik in eine zentrale Funktion `syncErfahrungMode()` die `#exp-simple` und `#exp-full` konsistent nach dem Zustand von `#exp-toggle` ein-/ausblendet.
- Ersetzt die duplizierte Inline-Logik im `change`-Handler des Toggles durch einen Aufruf von `syncErfahrungMode()` und behält anschließend `updateErfahrung()` und `saveState()` bei.
- Ruft `syncErfahrungMode()` nach `loadState()` in `initLogic()` auf, damit beim ersten Laden sofort der richtige Modus (inkl. „erweitert“) sichtbar ist.
- Geänderte Datei: `js/logic.js`.

### Testing
- Führte `npm test` aus; das Projekt hat nur einen Platzhalter-Test und der Befehl lief erfolgreich.
- Führte `npm run lint`; der Linter schlug fehl, weil keine ESLint-Konfiguration im Repo vorhanden ist, das ist nicht durch die Änderung verursacht worden.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b533893e408330adf5a47aff35ec5b)