### PR TITLE
Adjust mobile states layout and counter controls

### DIFF
--- a/css/style-mobile.css
+++ b/css/style-mobile.css
@@ -1180,7 +1180,7 @@ th[data-input]::before {
 
 .state-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1px;
   background: var(--color-table-line);
 }
@@ -1240,13 +1240,17 @@ th[data-input]::before {
 
 .state-counter {
   display: grid;
-  grid-template-columns: 24px minmax(0, 1fr) 24px;
-  gap: 4px;
+  grid-template-columns: minmax(0, 1fr);
+  grid-auto-rows: min-content;
+  justify-items: center;
+  gap: 2px;
   align-items: center;
 }
 
 .state-counter input {
-  min-width: 0;
+  width: 2ch;
+  max-width: 2ch;
+  min-width: 2ch;
   text-align: center;
 }
 


### PR DESCRIPTION
### Motivation
- Improve the mobile `Zustände` segment layout to show two state cards per row again and keep the internal card borders and overall styling unchanged.
- Make the state counter controls vertically stacked so the increment arrow appears above and the decrement arrow below the numeric value, and limit the numeric field to two-character width for compact display.

### Description
- Changed `css/style-mobile.css` to set `.state-grid` to `grid-template-columns: repeat(2, minmax(0, 1fr));` to force two cards per row on mobile.
- Reworked `.state-counter` in `css/style-mobile.css` to use a single-column grid with `grid-auto-rows: min-content` and centered items so the step buttons stack vertically around the value.
- Constrained the counter input by setting `.state-counter input` width/min-width/max-width to `2ch` so it fits a two-digit value.

### Testing
- Ran `npm test`, which reported "No tests specified" (no unit tests to run).
- Ran `npm run lint`, which failed because an ESLint configuration file is not present in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c24815610883308917e691332e372a)