### PR TITLE
Fix condition icon state after loading

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -639,6 +639,7 @@ function loadState() {
   syncExperienceMode();
   updateAttributes();
   restoreMarkers();
+  syncStateCardsFromInputs();
   ensureInitialRows();
   updateCharacterDisplay();
 }
@@ -2105,6 +2106,18 @@ function setStateCardActive(stateKey, active, { resetValue = false } = {}) {
   }
 }
 
+function syncStateCardsFromInputs() {
+  document.querySelectorAll('[data-state-card]').forEach(card => {
+    const stateKey = card.dataset.stateKey;
+    const input = document.getElementById(`state-${stateKey}-value`);
+    if (!input) return;
+    const value = clampStateValue(parseInt(input.value, 10) || 0);
+    input.value = String(value);
+    setStateCardActive(stateKey, value > 0, { resetValue: value === 0 });
+  });
+  updateStatesSummary();
+}
+
 function updateStatesSummary() {
   const container = document.getElementById('states-summary');
   if (!container) return;
@@ -2153,11 +2166,6 @@ function initStatesSection() {
     const stateKey = card.dataset.stateKey;
     const input = document.getElementById(`state-${stateKey}-value`);
     const toggle = card.querySelector('[data-state-toggle]');
-    if (input) {
-      input.value = String(clampStateValue(parseInt(input.value, 10) || 0));
-    }
-    const active = (parseInt(input?.value, 10) || 0) > 0;
-    setStateCardActive(stateKey, active, { resetValue: !active });
     toggle?.addEventListener('click', () => {
       const isActive = card.classList.contains('active');
       setStateCardActive(stateKey, !isActive, { resetValue: isActive });
@@ -2178,7 +2186,7 @@ function initStatesSection() {
     button.addEventListener('click', () => openStateInfo(button.dataset.stateKey));
   });
 
-  updateStatesSummary();
+  syncStateCardsFromInputs();
 }
 
 // =========================


### PR DESCRIPTION
### Motivation
- Condition icons remained visually inactive after loading a character even when saved values were > 0, because the UI classes/text were only updated when values were changed interactively.

### Description
- Add a new helper `syncStateCardsFromInputs()` to clamp input values, set card active/inactive classes, update binary labels and call `updateStatesSummary()`.
- Call `syncStateCardsFromInputs()` from `loadState()` so saved state values immediately reflect in the condition cards.
- Replace the per-card initial sync in `initStatesSection()` with a call to `syncStateCardsFromInputs()` to reuse the same logic and keep behavior consistent.
- Changes are limited to `js/logic.js` and keep existing behavior for toggles/step buttons and state persistence.

### Testing
- Ran `npm test` which is a noop in this repo and completed successfully.
- Ran `node --check js/logic.js && node --check js/sections.js` which reported no syntax errors.
- Ran `npm run lint` / `eslint` but it could not complete due to missing ESLint configuration in the repository (reported and not blocking the fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c393edbc833090409466afa2ffbd)